### PR TITLE
Add ConfigHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ dependencies {
 - pkstDev
 - Jim Jim aka FatherCheese
 - ICantTellYou
+- youngsditch

--- a/src/main/java/turniplabs/halplibe/util/ConfigHandler.java
+++ b/src/main/java/turniplabs/halplibe/util/ConfigHandler.java
@@ -1,0 +1,106 @@
+package turniplabs.halplibe.util;
+
+import turniplabs.halplibe.HalpLibe;
+
+import java.io.*;
+import java.util.Properties;
+
+public class ConfigHandler {
+  private static final String CONFIG_DIRECTORY = "./config/";
+  private String configFileName = "";
+  private Properties defaultProperties;
+  private Properties properties;
+
+  public String getFilePath() {
+    return CONFIG_DIRECTORY + configFileName;
+  }
+
+  public ConfigHandler(String modID, Properties defaultProperties) {
+    this.configFileName = modID + ".cfg";
+    this.defaultProperties = defaultProperties;
+    this.properties = new Properties();
+    this.properties.putAll(defaultProperties);
+    HalpLibe.LOGGER.info("Config file name: " + this.properties.toString());
+
+    File configFile = new File(getFilePath());
+    HalpLibe.LOGGER.info("Config file path: " + configFile.getAbsolutePath());
+    try {
+      if (!configFile.exists()) {
+        HalpLibe.LOGGER.info("Config file does not exist. Creating...");
+        configFile.getParentFile().mkdirs();
+        configFile.createNewFile();
+        writeDefaultConfig(configFile, this.defaultProperties);
+      } else {
+        // load only pulls in the ones we have in the file
+        loadConfig(configFile, this.properties);
+        // to make sure any new properties are added, we update the config
+        updateConfig(configFile, this.properties);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public String getProperty(String key) {
+    return this.properties.getProperty(key);
+  }
+
+  public String getString(String key) {
+    return this.properties.getProperty(key);
+  }
+
+  public Integer getInt(String key) {
+    return Integer.parseInt(this.properties.getProperty(key));
+  }
+
+  public Boolean getBoolean(String key) {
+    return Boolean.parseBoolean(this.properties.getProperty(key));
+  }
+
+  public void writeDefaultConfig() {
+    File configFile = new File(getFilePath());
+    writeDefaultConfig(configFile, this.defaultProperties);
+  }
+
+  public void loadConfig() {
+    File configFile = new File(getFilePath());
+    loadConfig(configFile, this.properties);
+  }
+
+  public void updateConfig() {
+    File configFile = new File(getFilePath());
+    updateConfig(configFile, this.properties);
+  }
+
+  // private
+
+  private static void writeDefaultConfig(File configFile, Properties properties) {
+    HalpLibe.LOGGER.info("Writing default config to " + configFile.getAbsolutePath());
+    try (OutputStream output = new FileOutputStream(configFile)) {
+      properties.store(output, "Default config values");
+      output.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static void updateConfig(File configFile, Properties properties) {
+    HalpLibe.LOGGER.info("Updating config at " + configFile.getAbsolutePath());
+    try (OutputStream output = new FileOutputStream(configFile)) {
+      properties.store(output, "Updated config values");
+      output.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static void loadConfig(File configFile, Properties properties) {
+    try (InputStream input = new FileInputStream(configFile)) {
+      // only loads the ones that it finds in the file
+      properties.load(input);
+      input.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
Intended to be used to as a tool to easily sync configs to file, while giving a modder the ability to add new configs and provide defaults. You pass in a list of configs, it attempts to load configs from a .cfg file, and saves any missing configs back to file as whatever their defaults were. There are some helper methods to get the data back as the right type.

Example Usage:

```
package youngsditch.ancientlogistics;

import turniplabs.halplibe.helper.*;
import turniplabs.halplibe.util.ConfigHandler;
import net.minecraft.src.*;
import net.fabricmc.api.ModInitializer;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
import java.util.Properties;
 
public class AncientLogistics implements ModInitializer {
    public static final String MOD_ID = "ancientlogistics";
    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
    public static final ConfigHandler config = new ConfigHandler(MOD_ID, new Properties() {{
        put("shovelID", "140");
        put("wandID", "141");
        put("allowBiomeMeter", "true");
        put("energyName", "Energy");
        // More keys and values...
    }});

    public static final Item shovel = ItemHelper.createItem(MOD_ID, new Item(config.getInt("shovelID")), "shovel", "shovel.png");

    @Override
    public void onInitialize() {

        LOGGER.info("AncientLogistics initialized.");
    }
}
```