### PR TITLE
NetworkHelper Fixes

### DIFF
--- a/src/main/java/turniplabs/halplibe/mixin/mixins/network/NetworkManagerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/mixins/network/NetworkManagerMixin.java
@@ -22,8 +22,8 @@ public class NetworkManagerMixin {
 
     @Inject(at = @At("TAIL"), method = "<init>")
     public void postInit(Socket socket, String s, NetHandler nethandler, CallbackInfo ci) {
-        field_28144_e = new int[NetworkHelper.getLastPacketId()];
-        field_28145_d = new int[NetworkHelper.getLastPacketId()];
+        field_28144_e = new int[NetworkHelper.getLastPacketId() + 1];
+        field_28145_d = new int[NetworkHelper.getLastPacketId() + 1];
     }
 
     // Increase id size when needed

--- a/src/main/java/turniplabs/halplibe/mixin/mixins/network/NetworkManagerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/mixins/network/NetworkManagerMixin.java
@@ -2,10 +2,13 @@ package turniplabs.halplibe.mixin.mixins.network;
 
 import net.minecraft.core.net.NetworkManager;
 import net.minecraft.core.net.handler.NetHandler;
+import net.minecraft.core.net.packet.Packet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.helper.NetworkHelper;
 
@@ -21,5 +24,31 @@ public class NetworkManagerMixin {
     public void postInit(Socket socket, String s, NetHandler nethandler, CallbackInfo ci) {
         field_28144_e = new int[NetworkHelper.getLastPacketId()];
         field_28145_d = new int[NetworkHelper.getLastPacketId()];
+    }
+
+    // Increase id size when needed
+
+    @Unique
+    public int extendedPacketSize(Packet packet){
+        // Add on the additional 3 bytes of id
+        return packet.getPacketSize() + (NetworkHelper.useExtendedPacketID() ? 3 : 0);
+    }
+    @Redirect(
+            method = "addToSendQueue(Lnet/minecraft/core/net/packet/Packet;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/core/net/packet/Packet;getPacketSize()I"))
+    private int addToSendQueue_SizeIncrease(Packet instance){
+        return extendedPacketSize(instance);
+    }
+    @Redirect(
+            method = "sendPacket()Z",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/core/net/packet/Packet;getPacketSize()I"))
+    private int sendPacket_SizeIncrease(Packet instance){
+        return extendedPacketSize(instance);
+    }
+    @Redirect(
+            method = "readPacket()Z",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/core/net/packet/Packet;getPacketSize()I"))
+    private int readPacket_SizeIncrease(Packet instance){
+        return extendedPacketSize(instance);
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/mixins/network/PacketMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/mixins/network/PacketMixin.java
@@ -14,13 +14,13 @@ import java.io.IOException;
 public class PacketMixin {
     @Redirect(at = @At(value = "INVOKE", target = "Ljava/io/DataOutputStream;write(I)V"), method = "writePacket")
     private static void preWrite(DataOutputStream instance, int b) throws IOException {
-        if (NetworkHelper.getLastPacketId() > 255) instance.writeInt(b);
+        if (NetworkHelper.useExtendedPacketID()) instance.writeInt(b);
         else instance.write(b);
     }
 
     @Redirect(at = @At(value = "INVOKE", target = "Ljava/io/DataInputStream;read()I"), method = "readPacket")
     private static int preWrite(DataInputStream instance) throws IOException {
-        if (NetworkHelper.getLastPacketId() > 255) return instance.readInt();
+        if (NetworkHelper.useExtendedPacketID()) return instance.readInt();
         else return instance.read();
     }
 }


### PR DESCRIPTION
Now checks that class extends Packet rather than is Packet now actually adds on the extended id size to the packet size when needed