### PR TITLE
Extended Mob ID space

### DIFF
--- a/src/main/java/turniplabs/halplibe/HalpLibe.java
+++ b/src/main/java/turniplabs/halplibe/HalpLibe.java
@@ -4,12 +4,11 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import turniplabs.halplibe.helper.*;
+import turniplabs.halplibe.helper.AchievementHelper;
+import turniplabs.halplibe.helper.NetworkHelper;
 import turniplabs.halplibe.util.achievements.AchievementPage;
 import turniplabs.halplibe.util.achievements.VanillaAchievementsPage;
-
-import java.io.File;
-import java.util.Properties;
+import turniplabs.halplibe.util.network.PacketExtendedMobSpawn;
 
 public class HalpLibe implements ModInitializer, PreLaunchEntrypoint {
     public static final String MOD_ID = "halplibe";
@@ -31,6 +30,7 @@ public class HalpLibe implements ModInitializer, PreLaunchEntrypoint {
     @Override
     public void onInitialize() {
         AchievementHelper.addPage(VANILLA_ACHIEVEMENTS);
+        NetworkHelper.register(PacketExtendedMobSpawn.class, false, true);
         LOGGER.info("HalpLibe initialized.");
     }
 

--- a/src/main/java/turniplabs/halplibe/mixin/mixins/network/EntityTrackerEntryMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/mixins/network/EntityTrackerEntryMixin.java
@@ -1,0 +1,26 @@
+package turniplabs.halplibe.mixin.mixins.network;
+
+import net.minecraft.core.entity.Entity;
+import net.minecraft.core.entity.EntityDispatcher;
+import net.minecraft.core.entity.EntityLiving;
+import net.minecraft.core.entity.EntityTrackerEntry;
+import net.minecraft.core.entity.animal.IAnimal;
+import net.minecraft.core.net.packet.Packet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import turniplabs.halplibe.util.network.PacketExtendedMobSpawn;
+
+@Mixin(value = EntityTrackerEntry.class, remap = false)
+public class EntityTrackerEntryMixin {
+    @Shadow public Entity trackedEntity;
+
+    @Inject(method = "getSpawnPacket()Lnet/minecraft/core/net/packet/Packet;", at = @At(value = "HEAD"), cancellable = true)
+    public void sendExtendedMobPacket(CallbackInfoReturnable<Packet> cir){
+        if (trackedEntity instanceof IAnimal && EntityDispatcher.getEntityID(trackedEntity) > 255){
+            cir.setReturnValue(new PacketExtendedMobSpawn((EntityLiving)trackedEntity));
+        }
+    }
+}

--- a/src/main/java/turniplabs/halplibe/mixin/mixins/network/EntityTrackerEntryMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/mixins/network/EntityTrackerEntryMixin.java
@@ -1,11 +1,11 @@
 package turniplabs.halplibe.mixin.mixins.network;
 
-import net.minecraft.core.entity.Entity;
-import net.minecraft.core.entity.EntityDispatcher;
-import net.minecraft.core.entity.EntityLiving;
-import net.minecraft.core.entity.EntityTrackerEntry;
+import net.minecraft.core.entity.*;
 import net.minecraft.core.entity.animal.IAnimal;
+import net.minecraft.core.entity.vehicle.EntityBoat;
+import net.minecraft.core.entity.vehicle.EntityMinecart;
 import net.minecraft.core.net.packet.Packet;
+import net.minecraft.server.entity.player.EntityPlayerMP;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,6 +19,7 @@ public class EntityTrackerEntryMixin {
 
     @Inject(method = "getSpawnPacket()Lnet/minecraft/core/net/packet/Packet;", at = @At(value = "HEAD"), cancellable = true)
     public void sendExtendedMobPacket(CallbackInfoReturnable<Packet> cir){
+        if (trackedEntity instanceof EntityItem || trackedEntity instanceof EntityPlayerMP || trackedEntity instanceof EntityMinecart || trackedEntity instanceof EntityBoat) {return;} // Makes sure to not interfere with the other instance checks before IAnimal
         if (trackedEntity instanceof IAnimal && EntityDispatcher.getEntityID(trackedEntity) > 255){
             cir.setReturnValue(new PacketExtendedMobSpawn((EntityLiving)trackedEntity));
         }

--- a/src/main/java/turniplabs/halplibe/mixin/mixins/network/NetClientHandlerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/mixins/network/NetClientHandlerMixin.java
@@ -1,0 +1,53 @@
+package turniplabs.halplibe.mixin.mixins.network;
+
+import com.b100.utils.StringUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.net.handler.NetClientHandler;
+import net.minecraft.client.world.WorldClient;
+import net.minecraft.core.entity.EntityDispatcher;
+import net.minecraft.core.entity.EntityLiving;
+import net.minecraft.core.net.packet.Packet24MobSpawn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.util.network.PacketExtendedMobSpawn;
+
+import java.util.List;
+
+@Mixin(value = NetClientHandler.class, remap = false)
+public class NetClientHandlerMixin {
+    @Shadow private WorldClient worldClient;
+
+    @Shadow private Minecraft mc;
+
+    @Inject(method = "handleMobSpawn(Lnet/minecraft/core/net/packet/Packet24MobSpawn;)V",
+            at = @At(value = "HEAD", target = "Lnet/minecraft/core/entity/EntityDispatcher;createEntity(ILnet/minecraft/core/world/World;)Lnet/minecraft/core/entity/Entity;"),
+            cancellable = true)
+    public void createEntity(Packet24MobSpawn packet24mobspawn, CallbackInfo ci){
+        if (packet24mobspawn instanceof PacketExtendedMobSpawn){
+            PacketExtendedMobSpawn extendedMobSpawn = (PacketExtendedMobSpawn)packet24mobspawn;
+            double d = (double)extendedMobSpawn.xPosition / 32.0;
+            double d1 = (double)extendedMobSpawn.yPosition / 32.0;
+            double d2 = (double)extendedMobSpawn.zPosition / 32.0;
+            float f = (float)(extendedMobSpawn.yaw * 360) / 256.0f;
+            float f1 = (float)(extendedMobSpawn.pitch * 360) / 256.0f;
+            EntityLiving entityliving = (EntityLiving) EntityDispatcher.createEntity(extendedMobSpawn.type, this.mc.theWorld);
+            entityliving.serverPosX = extendedMobSpawn.xPosition;
+            entityliving.serverPosY = extendedMobSpawn.yPosition;
+            entityliving.serverPosZ = extendedMobSpawn.zPosition;
+            entityliving.id = extendedMobSpawn.entityId;
+            entityliving.absMoveTo(d, d1, d2, f, f1);
+            entityliving.isMultiplayerEntity = true;
+            this.worldClient.func_712_a(extendedMobSpawn.entityId, entityliving);
+            List list = extendedMobSpawn.getMetadata();
+            if (list != null) {
+                entityliving.getEntityData().assignValues(list);
+            }
+            entityliving.nickname = StringUtils.substring(extendedMobSpawn.nickname, 0, 32);
+            entityliving.chatColor = extendedMobSpawn.chatColor;
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/turniplabs/halplibe/util/network/PacketExtendedMobSpawn.java
+++ b/src/main/java/turniplabs/halplibe/util/network/PacketExtendedMobSpawn.java
@@ -1,0 +1,85 @@
+package turniplabs.halplibe.util.network;
+
+import net.minecraft.core.entity.EntityDispatcher;
+import net.minecraft.core.entity.EntityLiving;
+import net.minecraft.core.net.handler.NetHandler;
+import net.minecraft.core.net.packet.Packet24MobSpawn;
+import net.minecraft.core.util.helper.MathHelper;
+import net.minecraft.core.world.data.SynchedEntityData;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class PacketExtendedMobSpawn extends Packet24MobSpawn {
+    public int entityId;
+    public int type;
+    public int xPosition;
+    public int yPosition;
+    public int zPosition;
+    public byte yaw;
+    public byte pitch;
+    private SynchedEntityData metaData;
+    private List receivedMetadata;
+    public String nickname;
+    public byte chatColor;
+
+    public PacketExtendedMobSpawn() {
+    }
+
+    public PacketExtendedMobSpawn(EntityLiving entityliving) {
+        this.entityId = entityliving.id;
+        this.type = EntityDispatcher.getEntityID(entityliving);
+        this.xPosition = MathHelper.floor_double(entityliving.x * 32.0);
+        this.yPosition = MathHelper.floor_double(entityliving.y * 32.0);
+        this.zPosition = MathHelper.floor_double(entityliving.z * 32.0);
+        this.yaw = (byte)(entityliving.yRot * 256.0f / 360.0f);
+        this.pitch = (byte)(entityliving.xRot * 256.0f / 360.0f);
+        this.metaData = entityliving.getEntityData();
+        this.nickname = entityliving.nickname;
+        this.chatColor = entityliving.chatColor;
+    }
+
+    @Override
+    public void readPacketData(DataInputStream dis) throws IOException {
+        this.entityId = dis.readInt();
+        this.type = dis.readInt();
+        this.xPosition = dis.readInt();
+        this.yPosition = dis.readInt();
+        this.zPosition = dis.readInt();
+        this.yaw = dis.readByte();
+        this.pitch = dis.readByte();
+        this.receivedMetadata = SynchedEntityData.unpack(dis);
+        this.nickname = Packet24MobSpawn.readString(dis, 32);
+        this.chatColor = dis.readByte();
+    }
+
+    @Override
+    public void writePacketData(DataOutputStream dos) throws IOException {
+        dos.writeInt(this.entityId);
+        dos.writeInt(this.type);
+        dos.writeInt(this.xPosition);
+        dos.writeInt(this.yPosition);
+        dos.writeInt(this.zPosition);
+        dos.writeByte(this.yaw);
+        dos.writeByte(this.pitch);
+        this.metaData.packAll(dos);
+        Packet24MobSpawn.writeString(this.nickname, dos);
+        dos.writeByte(this.chatColor);
+    }
+
+    @Override
+    public void processPacket(NetHandler netHandler) {
+        netHandler.handleMobSpawn(this);
+    }
+
+    @Override
+    public int getPacketSize() {
+        return 23;
+    }
+
+    public List getMetadata() {
+        return this.receivedMetadata;
+    }
+}

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -23,12 +23,14 @@
     "mixins.I18nMixin",
     "mixins.RenderEngineMixin",
     "mixins.RenderGlobalMixin",
+    "mixins.network.EntityTrackerEntryMixin",
     "mixins.network.MinecraftServerMixin",
+    "mixins.network.NetClientHandlerMixin",
     "mixins.network.NetworkManagerMixin",
     "mixins.network.PacketMixin",
-    "mixins.registry.MinecraftServerMixin",
     "mixins.registry.BlockMixin",
-    "mixins.registry.ItemMixin"
+    "mixins.registry.ItemMixin",
+    "mixins.registry.MinecraftServerMixin"
   ],
   "client": [
     "mixins.network.MinecraftMixin",


### PR DESCRIPTION
Multiplayer can now support mobs with EntityDispatcher IDs as an Int instead of just a byte