### PR TITLE
Allow RecipeBuilderBase.create to take IItemConvertible

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/recipeBuilders/RecipeBuilderBase.java
+++ b/src/main/java/turniplabs/halplibe/helper/recipeBuilders/RecipeBuilderBase.java
@@ -1,6 +1,7 @@
 package turniplabs.halplibe.helper.recipeBuilders;
 
 import net.minecraft.core.item.ItemStack;
+import net.minecraft.core.item.IItemConvertible;
 
 import java.util.Objects;
 
@@ -26,8 +27,18 @@ public abstract class RecipeBuilderBase implements Cloneable {
     /**
      * Creates a new recipe from the provided builder arguments.
      * @param recipeID Recipe identifier to assign to the created recipe
+     * @param output Result of crafting the specified recipe
+     */
+    @SuppressWarnings({"unused"})
+    public void create(String recipeID, IItemConvertible output) {
+        create(recipeID, output.getDefaultStack());
+    }
+
+    /**
+     * Creates a new recipe from the provided builder arguments.
+     * @param recipeID Recipe identifier to assign to the created recipe
      * @param outputStack Result of crafting the specified recipe
      */
     @SuppressWarnings({"unused"})
-    protected abstract void create( String recipeID, ItemStack outputStack);
+    public abstract void create(String recipeID, ItemStack outputStack);
 }

--- a/src/main/java/turniplabs/halplibe/helper/recipeBuilders/RecipeBuilderTrommel.java
+++ b/src/main/java/turniplabs/halplibe/helper/recipeBuilders/RecipeBuilderTrommel.java
@@ -114,7 +114,8 @@ public class RecipeBuilderTrommel extends RecipeBuilderBase{
                 .register(recipeID, new RecipeEntryTrommel(input, bag));
     }
     @Override
-    protected void create(String recipeID, ItemStack outputStack) {
+    public void create(String recipeID, ItemStack outputStack) throws IllegalArgumentException {
         // Standard create method doesn't apply to this class
+        throw new IllegalArgumentException("Use create(String recipeID), create(String recipeID, ItemStack outputStack) does not apply for trommels");
     }
 }


### PR DESCRIPTION
Just a minor QoL change, for example:
```java
// Before
RecipeBuilder.Shapeless(MOD_ID)
    .addInput(ModItems.foo)
    .addInput(ModItems.bar)
    .create("bazz", new ItemStack(ModItems.bazz));

// After
RecipeBuilder.Shapeless(MOD_ID)
    .addInput(ModItems.foo)
    .addInput(ModItems.bar)
    .create("bazz", ModItems.bazz);
```