### PR TITLE
Fix ItemStack Being Passed Metadata as Stack Size

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/CreativeHelper.java
+++ b/src/main/java/turniplabs/halplibe/helper/CreativeHelper.java
@@ -48,7 +48,7 @@ public final class CreativeHelper {
      */
     @SuppressWarnings("unused")
     public static void setParent(IItemConvertible itemToAdd, int metaToAdd, IItemConvertible itemParent, int metaParent){
-        setParent(new ItemStack(itemToAdd, 1, metaToAdd), new ItemStack(itemParent, metaParent));
+        setParent(new ItemStack(itemToAdd, 1, metaToAdd), new ItemStack(itemParent, 1, metaParent));
     }
     /**
      * @param itemToAdd The itemstack to be added to the creative inventory list


### PR DESCRIPTION
Fixes a bug I found in the CreativeHelper.
When initializing an ItemStack, the second parameter is the stack size, but in this case it was being passed the metadata.