### PR TITLE
Store CreativeEntry maps as LinkedHashMaps instead of HashMaps

### DIFF
--- a/src/main/java/turniplabs/halplibe/util/CreativeEntry.java
+++ b/src/main/java/turniplabs/halplibe/util/CreativeEntry.java
@@ -3,11 +3,11 @@ package turniplabs.halplibe.util;
 import net.minecraft.core.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 public class CreativeEntry implements Comparable<CreativeEntry> {
-    public static final HashMap<String, CreativeEntry> priorityEntryMap = new HashMap<>();
-    public static final HashMap<String, CreativeEntry> childEntryMap = new HashMap<>();
+    public static final LinkedHashMap<String, CreativeEntry> priorityEntryMap = new LinkedHashMap<>();
+    public static final LinkedHashMap<String, CreativeEntry> childEntryMap = new LinkedHashMap<>();
     public static void addEntry(CreativeEntry entry){
         String key = entry.stackToAdd.toString();
         if (entry.parentStack != null){


### PR DESCRIPTION
Fixes an issue I was having where I was trying to parent items to items that were also a part of my mod.
```
for (int index = NFCBlocks.windowVariants.length - 1; index >= 1 ; index--) {
    CreativeHelper.setParent(new ItemStack(NFCBlocks.window, 1, index), new ItemStack(NFCBlocks.window, 1, index - 1));
}
CreativeHelper.setParent(new ItemStack(NFCBlocks.window, 1, 0), new ItemStack(Block.glass.id, 1, 0));
```
Using a HashMap, the items will be parented to one another in an essentially random order, causing an issue where halplib can find the parent stack of an item only if they randomly happened to be parented before them.

Using a LinkedHashMap instead, given you set the parents in reverse such as in the example above, will behave in a more predictable way, and resolves my issue.