### PR TITLE
Update workflows file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,18 @@ jobs:
           17,    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
@@ -33,7 +34,7 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/


### PR DESCRIPTION
These are basically just the changes from the latest fabric example mod.

I chose to use temurin java instead of microsoft java.
My assumption is that fabric uses microsoft java because that's what most people playing modern minecraft would be using.
So, for BTA (I hope) most people would instead be using temurin.

I also changed the OS version to latest just because I don't know why you wouldn't. It works fine on my own projects but feel free to revert this.

Would be nice to see this on the example mod as well so that people that are maybe less experienced don't freak out when they see a red X next to their commit. Not sure if you'd want me to make a PR for that too.