### PR TITLE
New Entrypoints

### DIFF
--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -7,8 +7,11 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import turniplabs.halplibe.util.BlockInitEntrypoint;
 import turniplabs.halplibe.util.ClientStartEntrypoint;
 import turniplabs.halplibe.util.GameStartEntrypoint;
+import turniplabs.halplibe.util.ItemInitEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Mixin(
@@ -34,6 +37,16 @@ public class MinecraftMixin {
     public void afterGameStartEntrypoint(CallbackInfo ci){
         FabricLoader.getInstance().getEntrypoints("afterGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::afterGameStart);
         FabricLoader.getInstance().getEntrypoints("afterClientStart", ClientStartEntrypoint.class).forEach(ClientStartEntrypoint::afterClientStart);
+    }
+
+    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
+    public void afterBlockInitEntrypoint(CallbackInfo callbackInfo) {
+        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);;
+    }
+
+    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
+    public void afterItemInitEntrypoint(CallbackInfo callbackInfo) {
+        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);;
     }
 
     @Inject(method = "printWrongJavaVersionInfo", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
@@ -1,0 +1,5 @@
+package turniplabs.halplibe.util;
+
+public interface BlockInitEntrypoint {
+    void afterBlockInit();
+}

--- a/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
@@ -1,0 +1,5 @@
+package turniplabs.halplibe.util;
+
+public interface ItemInitEntrypoint {
+    void afterItemInit();
+}


### PR DESCRIPTION
A couple times now on separate mods I've needed either Minecraft's blocks or items to have finished being initialized in order to initialize my own blocks/items. It's especially useful to use the CreativeHelper within afterItemInit (or otherwise something like the recipe entrypoint) as you Minecraft's items need to have been initialized in order to parent to them without having to do something hack-y. So, it would be nice to just have these in halplibe so I don't have to recreate these entrypoints everytime.