### PR TITLE
Make the networking simpler and universal for everyone

### DIFF
--- a/src/main/java/turniplabs/halplibe/HalpLibe.java
+++ b/src/main/java/turniplabs/halplibe/HalpLibe.java
@@ -13,6 +13,8 @@ import net.minecraft.core.block.Block;
 import net.minecraft.core.item.Item;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import turniplabs.halplibe.helper.NetworkHelper;
+import turniplabs.halplibe.helper.network.NetworkHandler;
 import turniplabs.halplibe.util.ModelEntrypoint;
 import turniplabs.halplibe.util.TomlConfigHandler;
 import turniplabs.halplibe.util.toml.Toml;
@@ -38,6 +40,7 @@ public class HalpLibe implements ModInitializer, PreLaunchEntrypoint {
 
     @Override
     public void onInitialize() {
+        NetworkHandler.setup();
         LOGGER.info("HalpLibe initialized.");
     }
 

--- a/src/main/java/turniplabs/halplibe/HalpLibe.java
+++ b/src/main/java/turniplabs/halplibe/HalpLibe.java
@@ -40,7 +40,6 @@ public class HalpLibe implements ModInitializer, PreLaunchEntrypoint {
 
     @Override
     public void onInitialize() {
-        NetworkHandler.setup();
         LOGGER.info("HalpLibe initialized.");
     }
 

--- a/src/main/java/turniplabs/halplibe/HalpLibe.java
+++ b/src/main/java/turniplabs/halplibe/HalpLibe.java
@@ -13,8 +13,6 @@ import net.minecraft.core.block.Block;
 import net.minecraft.core.item.Item;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import turniplabs.halplibe.helper.NetworkHelper;
-import turniplabs.halplibe.helper.network.NetworkHandler;
 import turniplabs.halplibe.util.ModelEntrypoint;
 import turniplabs.halplibe.util.TomlConfigHandler;
 import turniplabs.halplibe.util.toml.Toml;

--- a/src/main/java/turniplabs/halplibe/helper/EnvironmentHelper.java
+++ b/src/main/java/turniplabs/halplibe/helper/EnvironmentHelper.java
@@ -1,0 +1,23 @@
+package turniplabs.halplibe.helper;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.Global;
+
+public class EnvironmentHelper {
+    public static boolean isServerEnvironment() {
+        return Global.isServer;
+    }
+
+    public static boolean isSinglePlayer() {
+        if (Global.isServer) {
+            return false;
+        }
+
+        return !Minecraft.getMinecraft().isMultiplayerWorld();
+    }
+
+    public static boolean isClientWorld() {
+        return !isSinglePlayer() && !isServerEnvironment();
+    }
+
+}

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -244,6 +244,10 @@ public final class NetworkHandler
 
 		@Override
 		public void handle(NetworkContext context) {
+			if (EnvironmentHelper.isServerEnvironment()) {
+				return;
+			}
+
 			try {
 				NetworkHandler.packetReaders.clear();
 				NetworkHandler.packetIds.clear();

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 public final class NetworkHandler
 {
     private static final Map<Integer, BiConsumer<NetworkMessage.NetworkContext, UniversalPacket>> packetReaders = new HashMap<>();
+    private static final Map<String, Short> modIds = new HashMap<>();
     private static final Map<Class<?>, Integer> packetIds = new HashMap<>();
 
     private NetworkHandler()
@@ -45,9 +46,16 @@ public final class NetworkHandler
      * @param factory The factory for this type of message.
      */
     @SuppressWarnings({"unused"})
-    public static <T extends NetworkMessage> void registerNetworkMessage( int id, Supplier<T> factory )
+    public static <T extends NetworkMessage> void registerNetworkMessage( String modId, short id, Supplier<T> factory )
     {
-        registerNetworkMessage( id, getType( factory ), buf -> {
+        if (!modIds.containsKey(modId)) {
+           modIds.put(modId, (short)modId.length());
+        }
+
+        final int high = (modIds.get(modId) & 0xFFFF) << 16;
+        final int low = id & 0xFFFF;
+
+        registerNetworkMessage( high | low, getType( factory ), buf -> {
             T instance = factory.get();
             instance.fromBytes( buf );
             return instance;

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -1,0 +1,157 @@
+package turniplabs.halplibe.helper.network;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.entity.player.Player;
+import net.minecraft.core.net.packet.Packet;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.entity.player.PlayerServer;
+import turniplabs.halplibe.helper.EnvironmentHelper;
+import turniplabs.halplibe.helper.NetworkHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class NetworkHandler
+{
+    private static final Map<Integer, BiConsumer<NetworkMessage.NetworkContext, UniversalPacket>> packetReaders = new HashMap<>();
+    private static final Map<Class<?>, Integer> packetIds = new HashMap<>();
+
+    private NetworkHandler()
+    {
+    }
+
+    public static void setup()
+    {
+       NetworkHelper.register ( UniversalPacket.class, true, true );
+    }
+
+    public static void receiveUniversalPacket(NetworkMessage.NetworkContext context, UniversalPacket buffer )
+    {
+        int type = buffer.readByte();
+        packetReaders.get( type )
+                .accept( context, buffer );
+    }
+
+    /**
+     * Register a NetworkMessage, and a thread-unsafe handler for it.
+     *
+     * @param <T>     The type of the NetworkMessage to send.
+     * @param id      The identifier for this message type
+     * @param factory The factory for this type of message.
+     */
+    @SuppressWarnings({"unused"})
+    public static <T extends NetworkMessage> void registerNetworkMessage( int id, Supplier<T> factory )
+    {
+        registerNetworkMessage( id, getType( factory ), buf -> {
+            T instance = factory.get();
+            instance.fromBytes( buf );
+            return instance;
+        } );
+    }
+
+    /**
+     * Register a NetworkMessage, and a thread-unsafe handler for it.
+     *
+     * @param <T>     The type of the NetworkMessage to send.
+     * @param type    The class of the type of message to send.
+     * @param id      The identifier for this message type
+     * @param decoder The factory for this type of message.
+     */
+    private static <T extends NetworkMessage> void registerNetworkMessage( int id, Class<T> type, Function<UniversalPacket, T> decoder )
+    {
+        packetIds.put( type, id );
+        packetReaders.put( id, ( context, buf ) -> {
+            T result = decoder.apply( buf );
+            result.handle(context);
+        } );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static <T> Class<T> getType( Supplier<T> supplier )
+    {
+        return (Class<T>) supplier.get()
+                .getClass();
+    }
+
+    private static UniversalPacket encode(NetworkMessage message )
+    {
+        UniversalPacket buf = new UniversalPacket();
+        buf.writeByte( packetIds.get( message.getClass() ) );
+        message.toBytes( buf );
+        return buf;
+    }
+
+    @Environment(EnvType.CLIENT)
+    private static void sendToPlayerLocal(NetworkMessage message)
+    {
+        message.handle(new NetworkMessage.NetworkContext(Minecraft.getMinecraft().thePlayer));
+    }
+
+    @Environment(EnvType.SERVER)
+    private static void sendToPlayerServer(Player player, NetworkMessage message )
+    {
+        ((PlayerServer)player).playerNetServerHandler.sendPacket(encode(message));
+    }
+
+    /**
+     * Send a NetworkMessage to a specific Player from the server
+     * If we are in SinglePlayer this will skip encoding and directly call the message handle
+     */
+    @SuppressWarnings({"unused"})
+    public static void sendToPlayer(Player player, NetworkMessage message )
+    {
+        if (!EnvironmentHelper.isServerEnvironment()){
+            sendToPlayerLocal(message);
+            return;
+        }
+        sendToPlayerServer(player, message);
+    }
+
+    /**
+     * Send a NetworkMessage to all Players from the server
+     * If we are in SinglePlayer this will skip encoding and directly call the message handle
+     */
+    @SuppressWarnings({"unused"})
+    public static void sendToAllPlayers( NetworkMessage packet )
+    {
+        if (!EnvironmentHelper.isServerEnvironment()){
+            sendToPlayerLocal(packet);
+            return;
+        }
+        MinecraftServer.getInstance().playerList.sendPacketToAllPlayers(encode(packet));
+    }
+
+    /**
+     * Send a NetworkMessage to the Server from the player
+     * If we are in SinglePlayer this will skip encoding and directly call the message handle
+     */
+    @SuppressWarnings({"unused"})
+    @Environment( EnvType.CLIENT )
+    public static void sendToServer( NetworkMessage packet )
+    {
+        if (EnvironmentHelper.isSinglePlayer()){
+            sendToPlayerLocal(packet);
+            return;
+        }
+        Minecraft.getMinecraft().getSendQueue().addToSendQueue(encode(packet));
+    }
+
+    /**
+     * Send a NetworkMessage to all Players around a block from the server
+     * If we are in SinglePlayer this will skip encoding and directly call the message handle
+     */
+    @SuppressWarnings({"unused"})
+    public static void sendToAllAround(NetworkMessage packet, double x, double y, double z, double radius, int dimension )
+    {
+        if (!EnvironmentHelper.isServerEnvironment()){
+            sendToPlayerLocal(packet);
+            return;
+        }
+        MinecraftServer.getInstance().playerList.sendPacketToPlayersAroundPoint(x, y, z, radius, dimension, encode(packet));
+    }
+}

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -7,158 +7,265 @@ import net.minecraft.core.entity.player.Player;
 import net.minecraft.core.net.packet.Packet;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.entity.player.PlayerServer;
+import org.jetbrains.annotations.NotNull;
 import turniplabs.halplibe.helper.EnvironmentHelper;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class NetworkHandler
 {
-    private static final Map<Integer, BiConsumer<NetworkMessage.NetworkContext, UniversalPacket>> packetReaders = new HashMap<>();
-    private static final Map<String, Short> modIds = new HashMap<>();
-    private static final Map<Class<?>, Integer> packetIds = new HashMap<>();
+	private static final List<Supplier<NetworkMessage>> messagesToRegisterForServer = new LinkedList<>(Collections.singletonList(
+		MessageIdsNetworkMessage::new
+	));
 
-    private NetworkHandler()
-    {
-    }
+	private static final Map<Short, BiConsumer<NetworkMessage.NetworkContext, UniversalPacket>> packetReaders = new HashMap<>();
+	private static final Map<Class<?>, Short> packetIds = new HashMap<>();
 
-    public static void setup()
-    {
-        Packet.addMapping (88,  true, true, UniversalPacket.class );
-    }
+	private NetworkHandler()
+	{
+	}
 
-    public static void receiveUniversalPacket(NetworkMessage.NetworkContext context, UniversalPacket buffer )
-    {
-        int type = buffer.readInt();
-        packetReaders.get( type )
-                .accept( context, buffer );
-    }
+	public static void setup()
+	{
+		Packet.addMapping (88,  true, true, UniversalPacket.class );
 
-    /**
-     * Register a NetworkMessage, and a thread-unsafe handler for it.
-     *
-     * @param <T>     The type of the NetworkMessage to send.
-     * @param id      The identifier for this message type
-     * @param factory The factory for this type of message.
-     */
-    @SuppressWarnings({"unused"})
-    public static <T extends NetworkMessage> void registerNetworkMessage( String modId, int id, Supplier<T> factory )
-    {
-        if (!modIds.containsKey(modId)) {
-            modIds.put(modId, (short)modId.length());
-        }
+		register();
+	}
 
-        final int high = (modIds.get(modId) & 0xFFFF) << 16;
-        final int low = id & 0xFFFF;
+	public static void register()
+	{
+		packetReaders.clear();
+		packetIds.clear();
 
-        registerNetworkMessage( high | low, getType( factory ), buf -> {
-            T instance = factory.get();
-            instance.decodeFromUniversalPacket( buf );
-            return instance;
-        } );
-    }
+		for (Supplier<NetworkMessage> networkMessage : messagesToRegisterForServer) {
+			addNetworkMessage(networkMessage);
+		}
+	}
 
-    /**
-     * Register a NetworkMessage, and a thread-unsafe handler for it.
-     *
-     * @param <T>     The type of the NetworkMessage to send.
-     * @param type    The class of the type of message to send.
-     * @param id      The identifier for this message type
-     * @param decoder The factory for this type of message.
-     */
-    private static <T extends NetworkMessage> void registerNetworkMessage( int id, Class<T> type, Function<UniversalPacket, T> decoder )
-    {
-        packetIds.put( type, id );
-        packetReaders.put( id, ( context, buf ) -> {
-            T result = decoder.apply( buf );
-            result.handle(context);
-        } );
-    }
+	public static void receiveUniversalPacket(NetworkMessage.NetworkContext context, UniversalPacket buffer )
+	{
+		short type = buffer.readShort();
 
-    @SuppressWarnings( "unchecked" )
-    private static <T> Class<T> getType( Supplier<T> supplier )
-    {
-        return (Class<T>) supplier.get()
-                .getClass();
-    }
+		if (!packetReaders.containsKey(type)) {
+			return;
+		}
 
-    private static UniversalPacket encode(NetworkMessage message )
-    {
-        UniversalPacket buf = new UniversalPacket();
-        buf.writeInt( packetIds.get( message.getClass() ) );
-        message.encodeToUniversalPacket( buf );
-        return buf;
-    }
+		packetReaders.get( type )
+			.accept( context, buffer );
+	}
 
-    @Environment(EnvType.CLIENT)
-    private static void sendToPlayerLocal(NetworkMessage message)
-    {
-        message.handle(new NetworkMessage.NetworkContext(Minecraft.getMinecraft().thePlayer));
-    }
+	/**
+	 * Register a NetworkMessage, and a thread-unsafe handler for it.
+	 *
+	 * @param factory The factory for this type of message.
+	 */
+	@SuppressWarnings({"unused"})
+	public static void registerNetworkMessage( Supplier<NetworkMessage> factory )
+	{
+		messagesToRegisterForServer.add(factory);
+	}
 
-    @Environment(EnvType.SERVER)
-    private static void sendToPlayerServer(Player player, NetworkMessage message )
-    {
-        ((PlayerServer)player).playerNetServerHandler.sendPacket(encode(message));
-    }
+	/**
+	 * Register a NetworkMessage, and a thread-unsafe handler for it.
+	 *
+	 * @param <T>     The type of the NetworkMessage to send.
+	 * @param factory The factory for this type of message.
+	 */
+	@SuppressWarnings({"unused"})
+	public static <T extends NetworkMessage> void addNetworkMessage( Supplier<T> factory )
+	{
+		registerNetworkMessage((short) packetIds.size(), factory);
+	}
 
-    /**
-     * Send a NetworkMessage to a specific Player from the server
-     * If we are in SinglePlayer this will skip encoding and directly call the message handle
-     */
-    @SuppressWarnings({"unused"})
-    public static void sendToPlayer(Player player, NetworkMessage message )
-    {
-        if (!EnvironmentHelper.isServerEnvironment()){
-            sendToPlayerLocal(message);
-            return;
-        }
-        sendToPlayerServer(player, message);
-    }
+	/**
+	 * Register a NetworkMessage, and a thread-unsafe handler for it.
+	 *
+	 * @param <T>     The type of the NetworkMessage to send.
+	 * @param id      The identifier for this message type
+	 * @param factory The factory for this type of message.
+	 */
+	@SuppressWarnings({"unused"})
+	private static <T extends NetworkMessage> void registerNetworkMessage( short id, Supplier<T> factory )
+	{
+		registerNetworkMessage( id, getType( factory ), buf -> {
+			T instance = factory.get();
+			instance.decodeFromUniversalPacket( buf );
+			return instance;
+		} );
+	}
 
-    /**
-     * Send a NetworkMessage to all Players from the server
-     * If we are in SinglePlayer this will skip encoding and directly call the message handle
-     */
-    @SuppressWarnings({"unused"})
-    public static void sendToAllPlayers( NetworkMessage message )
-    {
-        if (!EnvironmentHelper.isServerEnvironment()){
-            sendToPlayerLocal(message);
-            return;
-        }
-        MinecraftServer.getInstance().playerList.sendPacketToAllPlayers(encode(message));
-    }
+	/**
+	 * Register a NetworkMessage, and a thread-unsafe handler for it.
+	 *
+	 * @param <T>     The type of the NetworkMessage to send.
+	 * @param type    The class of the type of message to send.
+	 * @param id      The identifier for this message type
+	 * @param decoder The factory for this type of message.
+	 */
+	private static <T extends NetworkMessage> void registerNetworkMessage( short id, Class<T> type, Function<UniversalPacket, T> decoder )
+	{
+		packetIds.put( type, id );
+		packetReaders.put( id, ( context, buf ) -> {
+			T result = decoder.apply( buf );
+			result.handle(context);
+		} );
+	}
 
-    /**
-     * Send a NetworkMessage to the Server from the player
-     * If we are in SinglePlayer this will skip encoding and directly call the message handle
-     */
-    @SuppressWarnings({"unused"})
-    @Environment( EnvType.CLIENT )
-    public static void sendToServer( NetworkMessage message )
-    {
-        if (EnvironmentHelper.isSinglePlayer()){
-            sendToPlayerLocal(message);
-            return;
-        }
-        Minecraft.getMinecraft().getSendQueue().addToSendQueue(encode(message));
-    }
+	@SuppressWarnings( "unchecked" )
+	private static <T> Class<T> getType( Supplier<T> supplier )
+	{
+		return (Class<T>) supplier.get()
+			.getClass();
+	}
 
-    /**
-     * Send a NetworkMessage to all Players around a block from the server
-     * If we are in SinglePlayer this will skip encoding and directly call the message handle
-     */
-    @SuppressWarnings({"unused"})
-    public static void sendToAllAround(double x, double y, double z, double radius, int dimension, NetworkMessage message )
-    {
-        if (!EnvironmentHelper.isServerEnvironment()){
-            sendToPlayerLocal(message);
-            return;
-        }
-        MinecraftServer.getInstance().playerList.sendPacketToPlayersAroundPoint(x, y, z, radius, dimension, encode(message));
-    }
+	private static UniversalPacket encode(NetworkMessage message )
+	{
+		UniversalPacket buf = new UniversalPacket();
+		buf.writeShort( packetIds.get( message.getClass() ) );
+		message.encodeToUniversalPacket( buf );
+		return buf;
+	}
+
+	@Environment(EnvType.CLIENT)
+	private static void sendToPlayerLocal(NetworkMessage message)
+	{
+		message.handle(new NetworkMessage.NetworkContext(Minecraft.getMinecraft().thePlayer));
+	}
+
+	@Environment(EnvType.SERVER)
+	private static void sendToPlayerServer(Player player, NetworkMessage message)
+	{
+		((PlayerServer)player).playerNetServerHandler.sendPacket(encode(message));
+	}
+
+	@Environment(EnvType.SERVER)
+	public static void sendToPlayerMessagesConfiguration(Player player)
+	{
+		((PlayerServer)player).playerNetServerHandler.sendPacket(encode(new MessageIdsNetworkMessage(packetIds)));
+	}
+
+	/**
+	 * Send a NetworkMessage to a specific Player from the server
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 */
+	@SuppressWarnings({"unused"})
+	public static void sendToPlayer(Player player, NetworkMessage message )
+	{
+		if (!EnvironmentHelper.isServerEnvironment()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		sendToPlayerServer(player, message);
+	}
+
+	/**
+	 * Send a NetworkMessage to all Players from the server
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 */
+	@SuppressWarnings({"unused"})
+	public static void sendToAllPlayers( NetworkMessage message )
+	{
+		if (!EnvironmentHelper.isServerEnvironment()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		MinecraftServer.getInstance().playerList.sendPacketToAllPlayers(encode(message));
+	}
+
+	/**
+	 * Send a NetworkMessage to the Server from the player
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 */
+	@SuppressWarnings({"unused"})
+	@Environment( EnvType.CLIENT )
+	public static void sendToServer( NetworkMessage message )
+	{
+		if (EnvironmentHelper.isSinglePlayer()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		Minecraft.getMinecraft().getSendQueue().addToSendQueue(encode(message));
+	}
+
+	/**
+	 * Send a NetworkMessage to all Players around a block from the server
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 */
+	@SuppressWarnings({"unused"})
+	public static void sendToAllAround(double x, double y, double z, double radius, int dimension, NetworkMessage message )
+	{
+		if (!EnvironmentHelper.isServerEnvironment()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		MinecraftServer.getInstance().playerList.sendPacketToPlayersAroundPoint(x, y, z, radius, dimension, encode(message));
+	}
+
+	private static class MessageIdsNetworkMessage implements NetworkMessage{
+			Map<Class<?>, Short> packetIds;
+
+			public MessageIdsNetworkMessage() {}
+
+			public MessageIdsNetworkMessage(Map<Class<?>, Short> packetIds) {
+				this.packetIds = packetIds;
+			}
+
+			@Override
+			public void encodeToUniversalPacket(@NotNull UniversalPacket packet) {
+				packet.writeShort((short) packetIds.size());
+
+				for (Map.Entry<Class<?>, Short> entry : packetIds.entrySet()) {
+					packet.writeShort(entry.getValue());
+					packet.writeString(entry.getKey().getName());
+				}
+			}
+
+			@Override
+			public void decodeFromUniversalPacket(@NotNull UniversalPacket packet) {
+				this.packetIds = new HashMap<>();
+
+				final short size = packet.readShort();
+
+				try {
+					for (int i = 0; i < size; i++) {
+						final short id = packet.readShort();
+						final Class<?> messageClass = Class.forName(packet.readString());
+
+						this.packetIds.put(messageClass, id);
+					}
+				} catch (ClassNotFoundException e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+		@Override
+		public void handle(NetworkContext context) {
+			try {
+				NetworkHandler.packetReaders.clear();
+				NetworkHandler.packetIds.clear();
+
+				for (Map.Entry<Class<?>, Short> entry : packetIds.entrySet()) {
+					Class<?> klass = entry.getKey();
+					if (NetworkMessage.class.isAssignableFrom(klass)) {
+						Supplier<NetworkMessage> supplier = () -> {
+							try {
+								return (NetworkMessage) klass.getDeclaredConstructor().newInstance();
+							} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+								throw new RuntimeException(e);
+							}
+						};
+						NetworkHandler.registerNetworkMessage(entry.getValue(), supplier);
+					} else {
+						throw new IllegalArgumentException("Class " + klass.getName() + " does not extend NetworkMessage");
+					}
+				}
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
 }

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
@@ -1,0 +1,42 @@
+package turniplabs.halplibe.helper.network;
+
+import net.minecraft.core.entity.player.Player;
+
+import javax.annotation.Nonnull;
+
+public interface NetworkMessage {
+    /**
+     * Write this packet to a buffer.
+     * This may be called on any thread, so this should be a pure operation.
+     *
+     * @param packet The packet to write data to.
+     */
+    void toBytes( @Nonnull UniversalPacket packet );
+
+    /**
+     * Read this packet from a buffer.
+     * This may be called on any thread, so this should be a pure operation.
+     *
+     * @param buf The packet to read data from.
+     */
+    void fromBytes( @Nonnull UniversalPacket buf );
+
+    /**
+     * Handle this {@link NetworkMessage}.
+     *
+     * @param context An intermediary representation of Packet handler common on both Client and Server environment.
+     */
+    void handle(NetworkContext context);
+
+    class NetworkContext {
+        /**
+         * The player that send the NetworkPacket to the handle
+         */
+        public Player player;
+
+        public NetworkContext(Player player) {
+            this.player = player;
+        }
+    }
+
+}

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
@@ -6,20 +6,20 @@ import javax.annotation.Nonnull;
 
 public interface NetworkMessage {
     /**
-     * Write this packet to a buffer.
+     * Encode the UniversalPacket into your NetworkMessage.
      * This may be called on any thread, so this should be a pure operation.
      *
      * @param packet The packet to write data to.
      */
-    void toBytes( @Nonnull UniversalPacket packet );
+    void encodeToUniversalPacket(@Nonnull UniversalPacket packet );
 
     /**
-     * Read this packet from a buffer.
+     * Decode the UniversalPacket into your NetworkMessage.
      * This may be called on any thread, so this should be a pure operation.
      *
-     * @param buf The packet to read data from.
+     * @param packet The packet to read data from.
      */
-    void fromBytes( @Nonnull UniversalPacket buf );
+    void decodeFromUniversalPacket(@Nonnull UniversalPacket packet );
 
     /**
      * Handle this {@link NetworkMessage}.

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
@@ -5,38 +5,38 @@ import net.minecraft.core.entity.player.Player;
 import javax.annotation.Nonnull;
 
 public interface NetworkMessage {
-    /**
-     * Encode the UniversalPacket into your NetworkMessage.
-     * This may be called on any thread, so this should be a pure operation.
-     *
-     * @param packet The packet to write data to.
-     */
-    void encodeToUniversalPacket(@Nonnull UniversalPacket packet );
+	/**
+	 * Encode the UniversalPacket into your NetworkMessage.
+	 * This may be called on any thread, so this should be a pure operation.
+	 *
+	 * @param packet The packet to write data to.
+	 */
+	void encodeToUniversalPacket(@Nonnull UniversalPacket packet );
 
-    /**
-     * Decode the UniversalPacket into your NetworkMessage.
-     * This may be called on any thread, so this should be a pure operation.
-     *
-     * @param packet The packet to read data from.
-     */
-    void decodeFromUniversalPacket(@Nonnull UniversalPacket packet );
+	/**
+	 * Decode the UniversalPacket into your NetworkMessage.
+	 * This may be called on any thread, so this should be a pure operation.
+	 *
+	 * @param packet The packet to read data from.
+	 */
+	void decodeFromUniversalPacket(@Nonnull UniversalPacket packet );
 
-    /**
-     * Handle this {@link NetworkMessage}.
-     *
-     * @param context An intermediary representation of Packet handler common on both Client and Server environment.
-     */
-    void handle(NetworkContext context);
+	/**
+	 * Handle this {@link NetworkMessage}.
+	 *
+	 * @param context An intermediary representation of Packet handler common on both Client and Server environment.
+	 */
+	void handle(NetworkContext context);
 
-    class NetworkContext {
-        /**
-         * The player that send the NetworkPacket to the handle
-         */
-        public Player player;
+	class NetworkContext {
+		/**
+		 * The player that send the NetworkPacket to the handle
+		 */
+		public Player player;
 
-        public NetworkContext(Player player) {
-            this.player = player;
-        }
-    }
+		public NetworkContext(Player player) {
+			this.player = player;
+		}
+	}
 
 }

--- a/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
@@ -1,0 +1,298 @@
+package turniplabs.halplibe.helper.network;
+
+import com.mojang.nbt.NbtIo;
+import com.mojang.nbt.tags.CompoundTag;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.net.handler.PacketHandler;
+import net.minecraft.core.net.packet.Packet;
+import org.jetbrains.annotations.NotNull;
+import turniplabs.halplibe.helper.EnvironmentHelper;
+import turniplabs.halplibe.mixin.accessors.PacketHandlerServerAccessor;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * UniversalPacket is a general purpose packet made to transport multiple message into the same PacketType
+ * This work similar as DataInput/DataOutput, netty ByteBuf or modern Minecraft PacketByteBuf
+ */
+public class UniversalPacket extends Packet {
+    private byte[] buffer;
+    private int writeIndex;
+    private int readIndex;
+
+    public UniversalPacket() {
+        this.buffer = new byte[0];
+        this.writeIndex = 0;
+        this.readIndex = 0;
+    }
+
+    @Deprecated
+    public void read(DataInputStream dis) throws IOException {
+        final int length = dis.readInt();
+        buffer = new byte[length];
+        writeIndex = dis.read(buffer, 0, length);
+    }
+
+    /**
+     * If you want to write the UniversalPacket content to a DataOutputStream, use rawWrite instead
+     * since this method add an extra 4 bytes to every packet
+     */
+    @Deprecated
+    public void write(DataOutputStream dos) throws IOException {
+        dos.writeInt(this.buffer.length);
+        dos.write(this.buffer);
+    }
+
+    @SuppressWarnings("unused")
+    public void rawWrite(DataOutputStream dos) throws IOException {
+        dos.write(this.buffer);
+    }
+
+    public void handlePacket(PacketHandler packetHandler) {
+        if (EnvironmentHelper.isServerEnvironment()) {
+            handlePacketServer(packetHandler);
+            return;
+        }
+        handlePacketClient();
+    }
+
+    @Environment(EnvType.SERVER)
+    private void handlePacketServer(PacketHandler packetHandler) {
+        NetworkHandler.receiveUniversalPacket(new NetworkMessage.NetworkContext((
+                (PacketHandlerServerAccessor)packetHandler).getPlayerEntity()
+        ), this);
+    }
+
+    @Environment(EnvType.CLIENT)
+    private void handlePacketClient() {
+        NetworkHandler.receiveUniversalPacket(new NetworkMessage.NetworkContext(
+                Minecraft.getMinecraft().thePlayer
+        ), this);
+    }
+
+    public int getEstimatedSize() {
+        return buffer.length;
+    }
+
+    @SuppressWarnings("unused")
+    public void writeByte(byte value) {
+        ensureCapacity(1);
+        buffer[writeIndex++] = value;
+    }
+
+    @SuppressWarnings("unused")
+    public void writeByte(int value) {
+        writeByte((byte) value);
+    }
+
+    @SuppressWarnings("unused")
+    public byte readByte() {
+        ensureReadable(1);
+        return buffer[readIndex++];
+    }
+
+    @SuppressWarnings("unused")
+    public void writeBytes(int... values) {
+        ensureCapacity(values.length);
+        for (int value : values) {
+            buffer[writeIndex++] = (byte) value;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public void writeBytes(byte... values) {
+        ensureCapacity(values.length);
+        for (int value : values) {
+            buffer[writeIndex++] = (byte) value;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public void readBytes(byte[] destination, int length) {
+        if (length > destination.length) {
+            throw new IllegalArgumentException("");
+        }
+        ensureReadable(length);
+        System.arraycopy(buffer, readIndex, destination, 0, length);
+        readIndex += length;
+    }
+
+    @SuppressWarnings("unused")
+    public void writeInt(int value) {
+        ensureCapacity(4);
+        buffer[writeIndex++] = (byte) (value >> 24);
+        buffer[writeIndex++] = (byte) (value >> 16);
+        buffer[writeIndex++] = (byte) (value >> 8);
+        buffer[writeIndex++] = (byte) value;
+    }
+
+    @SuppressWarnings("unused")
+    public int readInt() {
+        ensureReadable(4);
+        return ((buffer[readIndex++] & 0xFF) << 24) |
+                ((buffer[readIndex++] & 0xFF) << 16) |
+                ((buffer[readIndex++] & 0xFF) << 8) |
+                (buffer[readIndex++] & 0xFF);
+    }
+
+    @SuppressWarnings("unused")
+    public void writeShort(short value) {
+        ensureCapacity(2);
+        buffer[writeIndex++] = (byte) (value >> 8);
+        buffer[writeIndex++] = (byte) value;
+    }
+
+    @SuppressWarnings("unused")
+    public short readShort() {
+        ensureReadable(2);
+        return (short) (((buffer[readIndex++] & 0xFF) << 8) |
+                (buffer[readIndex++] & 0xFF));
+    }
+
+    @SuppressWarnings("unused")
+    public void writeString(String value) {
+        byte[] stringBytes = value.getBytes(StandardCharsets.UTF_8);
+        writeInt(stringBytes.length);
+        ensureCapacity(stringBytes.length);
+        System.arraycopy(stringBytes, 0, buffer, writeIndex, stringBytes.length);
+        writeIndex += stringBytes.length;
+    }
+
+    @SuppressWarnings("unused")
+    public String readString() {
+        int length = readInt();
+        ensureReadable(length);
+        String value = new String(buffer, readIndex, length, StandardCharsets.UTF_8);
+        readIndex += length;
+        return value;
+    }
+
+    @SuppressWarnings("unused")
+    public void writeBoolean(boolean value) {
+        ensureCapacity(1);
+        buffer[writeIndex++] = (byte) (value ? 1 : 0);
+    }
+
+    @SuppressWarnings("unused")
+    public boolean readBoolean() {
+        ensureReadable(1);
+        return buffer[readIndex++] != 0;
+    }
+
+    @SuppressWarnings("unused")
+    public void writeDouble(double value) {
+        long bits = Double.doubleToLongBits(value);
+        writeLong(bits);
+    }
+
+    @SuppressWarnings("unused")
+    public double readDouble() {
+        long bits = readLong();
+        return Double.longBitsToDouble(bits);
+    }
+
+    @SuppressWarnings("unused")
+    public void writeLong(long value) {
+        ensureCapacity(8);
+        for (int i = 7; i >= 0; i--) {
+            buffer[writeIndex++] = (byte) (value >> (i * 8));
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public long readLong() {
+        ensureReadable(8);
+        long value = 0;
+        for (int i = 0; i < 8; i++) {
+            value = (value << 8) | (buffer[readIndex++] & 0xFF);
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unused")
+    public void writeEnumConstant(Enum<?> instance) {
+        int ordinal = instance.ordinal();
+        this.writeByte(ordinal);
+    }
+
+    @SuppressWarnings("unused")
+    public <T extends Enum<T>> T readEnumConstant(Class<T> enumClass) {
+        int ordinal = this.readByte();
+        T[] enumConstants = enumClass.getEnumConstants();
+        return enumConstants[ordinal];
+    }
+
+    @SuppressWarnings("unused")
+    public void writeCompoundTag(CompoundTag tag) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            NbtIo.writeCompressed(tag, baos);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        byte[] buffer = baos.toByteArray();
+        writeShort((short)buffer.length);
+        writeBytes(buffer);
+    }
+
+    @SuppressWarnings("unused")
+    public CompoundTag readCompoundTag() {
+        int length = Short.toUnsignedInt(readShort());
+        if (length == 0) {
+            return null;
+        } else {
+            byte[] data = new byte[length];
+            readBytes(data, length);
+            try {
+                return NbtIo.readCompressed(new ByteArrayInputStream(data));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public InputStream readBytesAsStream(int length) {
+        ensureReadable(length);
+        return new InputStream() {
+            private int remaining = length;
+
+            @Override
+            public int read() {
+                if (remaining <= 0) {
+                    return -1;
+                }
+                remaining--;
+                return buffer[readIndex++] & 0xFF;
+            }
+
+            @Override
+            public int read(byte @NotNull [] b, int off, int len) {
+                if (remaining <= 0) {
+                    return -1;
+                }
+                int toRead = Math.min(len, remaining);
+                System.arraycopy(buffer, readIndex, b, off, toRead);
+                readIndex += toRead;
+                remaining -= toRead;
+                return toRead;
+            }
+        };
+    }
+
+    private void ensureCapacity(int length) {
+        if (writeIndex + length > buffer.length) {
+            buffer = Arrays.copyOf(buffer, buffer.length + length + 64);
+        }
+    }
+
+    private void ensureReadable(int length) {
+        if (readIndex + length > writeIndex) {
+            throw new IndexOutOfBoundsException("Not enough data to read.");
+        }
+    }
+}

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.helper.network.NetworkHandler;
 import turniplabs.halplibe.util.ClientStartEntrypoint;
 import turniplabs.halplibe.util.GameStartEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
@@ -32,6 +33,7 @@ public class MinecraftMixin {
 
     @Inject(method = "startGame", at = @At("TAIL"))
     public void afterGameStartEntrypoint(CallbackInfo ci){
+        NetworkHandler.setup();
         FabricLoader.getInstance().getEntrypoints("afterGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::afterGameStart);
         FabricLoader.getInstance().getEntrypoints("afterClientStart", ClientStartEntrypoint.class).forEach(ClientStartEntrypoint::afterClientStart);
     }

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import turniplabs.halplibe.helper.network.NetworkHandler;
 import turniplabs.halplibe.util.GameStartEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
@@ -24,6 +25,7 @@ public class MinecraftServerMixin {
     public void beforeGameStartEntrypoint(CallbackInfoReturnable<Boolean> cir){
         instance = (MinecraftServer)(Object)this;
         Global.isServer = true;
+        NetworkHandler.setup();
         FabricLoader.getInstance().getEntrypoints("beforeGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::beforeGameStart);
     }
 

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerLoginMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerLoginMixin.java
@@ -1,0 +1,23 @@
+package turniplabs.halplibe.mixin;
+
+import net.minecraft.core.net.packet.PacketLogin;
+import net.minecraft.server.entity.player.PlayerServer;
+import net.minecraft.server.net.handler.PacketHandlerLogin;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import turniplabs.halplibe.helper.network.NetworkHandler;
+
+@Mixin(value = PacketHandlerLogin.class, remap = false)
+public class PacketHandlerLoginMixin {
+		@Inject(method = "doLogin(Lnet/minecraft/core/net/packet/PacketLogin;)V", at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/server/net/handler/PacketHandlerServer;sendPacket(Lnet/minecraft/core/net/packet/Packet;)V",
+			ordinal = 0, shift = At.Shift.AFTER),
+			locals = LocalCapture.CAPTURE_FAILHARD
+		)
+		public void doLogin(PacketLogin packetlogin, CallbackInfo ci, PlayerServer player) {
+			NetworkHandler.sendToPlayerMessagesConfiguration(player);
+		}
+	}

--- a/src/main/java/turniplabs/halplibe/mixin/accessors/PacketHandlerServerAccessor.java
+++ b/src/main/java/turniplabs/halplibe/mixin/accessors/PacketHandlerServerAccessor.java
@@ -1,0 +1,12 @@
+package turniplabs.halplibe.mixin.accessors;
+
+import net.minecraft.server.entity.player.PlayerServer;
+import net.minecraft.server.net.handler.PacketHandlerServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = PacketHandlerServer.class, remap = false)
+public interface PacketHandlerServerAccessor {
+    @Accessor
+    PlayerServer getPlayerEntity();
+}

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -26,6 +26,7 @@
     "models.TileEntityRendererDispatcherMixin"
   ],
   "server": [
+    "PacketHandlerLoginMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -14,7 +14,8 @@
     "accessors.EntityFXAccessor",
     "accessors.LanguageAccessor",
     "accessors.WeightedRandomBagAccessor",
-    "accessors.WeightedRandomBagEntryAccessor"
+    "accessors.WeightedRandomBagEntryAccessor",
+    "accessors.PacketHandlerServerAccessor"
   ],
   "client": [
     "PacketHandlerClientMixin",


### PR DESCRIPTION
It's not a secret BTA networking is kind of a mystery for a lot of people.
They're also the fact that BTA got two kind of configuration, the client which we have the rendering and the server which with have the world logic. But this would forget that BTA also support an hybrid between the two called SinglePlayer.
Also the Packet system in BTA is prone too conflict since id are only one byte and the number of id available for everyone is limited.

This PR do two things to help this :
1. I introduce a tiny helper called the `EnvironmenttHelper` where we can easily know if we are : Server, Client, SinglePlayer
2. I add a new way to handle Packet called `NetworkMessage`

`NetworkMessage` is an Interface with a role similar as Packet except I don't force you to extend from a class and most important don't make you depend directly on the way BTA since sometime if you don't consume every byte send by BTA, some strange network error can occurred or more often garbage data will be read as invalid packet (trust me, this is weird like bug).

Here an example of a `NetworkMessage`
```java
public class OpenInventoryNetworkMessage implements NetworkMessage {
	String text;

	public OpenInventoryNetworkMessage() {}

	public OpenInventoryNetworkMessage(String text) {
		this.text = text;
	}


	@Override
	public void encodeToUniversalPacket(@NotNull UniversalPacket packet) {
		packet.writeString(text);
	}

	@Override
	public void decodeFromUniversalPacket(@NotNull UniversalPacket packet) {
		text = packet.readString();

	}

	/**
	 * This should be its own function since LocalPlayer don't exist on server environment
	 */
	@Environment(EnvType.CLIENT)
	private void clientOpenInventory() {
		final Player currentPlayer = Minecraft.getMinecraft().thePlayer;
		currentPlayer.displayContainerScreen(currentPlayer.inventory);
	}

	@Override
	public void handle(NetworkContext context) {
		ExampleMod.LOGGER.info("Receive the message : {}", text);
		if (EnvironmentHelper.isSinglePlayer() || EnvironmentHelper.isClientWorld()) {
			clientOpenInventory();
		}
	}
}
```
Here you can see our message is separate in three part :
- Encoding is where we will convert our Message object into an `UniversalPacket`
- Decoding is where we will read our `UniversalPacket` to reconstruct our message
- Handle will be executed when the received message is ready.

*Please note the network system I present you will skip the encoding and decoding if we try to send a packet from SinglePlayer for performance reason.*

In my example you can also see something I called the  `UniversalPacket`, this a class that instead from the BTA `Packet` and is 100% inspired by Java `DataInput` / `DataOutput`, netty `ByteBuf ` or modern Minecraft `PacketByteBuf`

This class has some more advantage than a Java data stream since it will never throw `IOException` or need try catch.
Also this class got some more Minecraft oriented helper like be capable to write or read NBT data directly in it.

So now we got our NetworkMessage, we need to register in the start of our game, for that it's very easy since we can literally register it our ModInitializer
```java
public class ExampleMod implements ModInitializer {
    public static final String MOD_ID = "examplemod";
    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
    @Override
    public void onInitialize() {
        LOGGER.info("ExampleMod initialized.");

		NetworkHandler.registerNetworkMessage(OpenInventoryNetworkMessage::new);
    }
}
```
The `NetworkHandler` is the master brain of the messaging system, your `NetworkMessage` and your message is ready to be send and receive from everywhere without any conflict ! It's magic !.

Now you can just use the `NetworkHandler` from everywhere to do thing like this :
```java
public class TestCommand implements CommandManager.CommandRegistry {

	@Override
	public void register(CommandDispatcher<CommandSource> commandDispatcher) {
		LiteralArgumentBuilder<CommandSource> builder = LiteralArgumentBuilder.<CommandSource>literal("test");

		builder.then(LiteralArgumentBuilder.<CommandSource>literal("openInventory").executes((c) -> {
			return 1;
		}).executes((c) -> {
			if (EnvironmentHelper.isServerEnvironment()){
				NetworkHandler.sendToAllPlayers(new OpenInventoryNetworkMessage("Hoi from server"));
				return 1;
			}
			if (EnvironmentHelper.isSinglePlayer()){
				NetworkHandler.sendToAllPlayers(new OpenInventoryNetworkMessage("Hoi from single player"));
			}
			return 1;
		}));

		commandDispatcher.register(builder);
	}
}
```

It's that easy, to recap all you need at the end using this abstraction is :
- Create your `NetworkMessage` with encoding, decoding and handling
- Register your `NetworkMessage` in your mod Initializer.
- Use `NetworkHander` from everywhere to send your message and profit !

For the full example in a tiny project you can look at here https://github.com/gungun974/halplibe-network-message-example
In this example I added the command `/test openInventory` which will send to the client console a message that contain a custom string from the server and will open the inventory for the player.

*Please note this is a demonstration of the messaging system, the code for opening the player inventory is a bit broken to be honest*.

Of course this PR is a proposal and I would hope to discuss on what we can approve. I think adding to `halplibe` a standard way to communicate the client server with SinglePlayer compatibility is something important for the future of BTA modding.

Thank for reading all of this ^^