### PR TITLE
Mixin warning and New Entrypoint Fix

### DIFF
--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -42,12 +42,12 @@ public class MinecraftMixin {
     }
 
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
-    public void afterBlockInitEntrypoint(CallbackInfo callbackInfo) {
+    public void afterBlockInitEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);;
     }
 
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
-    public void afterItemInitEntrypoint(CallbackInfo callbackInfo) {
+    public void afterItemInitEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);;
     }
 

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -9,7 +9,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import turniplabs.halplibe.helper.network.NetworkHandler;
+import turniplabs.halplibe.util.BlockInitEntrypoint;
 import turniplabs.halplibe.util.GameStartEntrypoint;
+import turniplabs.halplibe.util.ItemInitEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Mixin(value = MinecraftServer.class, remap = false)
@@ -32,6 +34,16 @@ public class MinecraftServerMixin {
     @Inject(method = "startServer", at = @At("TAIL"))
     public void afterGameStartEntrypoint(CallbackInfoReturnable<Boolean> cir){
         FabricLoader.getInstance().getEntrypoints("afterGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::afterGameStart);
+    }
+
+    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
+    public void afterBlockInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
+        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);;
+    }
+
+    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
+    public void afterItemInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
+        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);;
     }
 
     /*

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -5,27 +5,27 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "I18nMixin",
-    "MinecraftMixin",
-    "MinecraftServerMixin",
     "MobCreeperMixin",
     "accessors.BlockAccessor",
     "accessors.BlocksAccessor",
-    "accessors.EntityFireflyFXAccessor",
-    "accessors.EntityFXAccessor",
     "accessors.LanguageAccessor",
     "accessors.WeightedRandomBagAccessor",
     "accessors.WeightedRandomBagEntryAccessor",
     "accessors.PacketHandlerServerAccessor"
   ],
   "client": [
+    "MinecraftMixin",
     "PacketHandlerClientMixin",
     "models.BlockColorDispatcherMixin",
     "models.BlockModelDispatcherMixin",
     "models.EntityRenderDispatcherMixin",
     "models.ItemModelDispatcherMixin",
-    "models.TileEntityRendererDispatcherMixin"
+    "models.TileEntityRendererDispatcherMixin",
+    "accessors.EntityFireflyFXAccessor",
+    "accessors.EntityFXAccessor"
   ],
   "server": [
+    "MinecraftServerMixin",
     "PacketHandlerLoginMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Fixes the new entrypoints from PR #69 not working on multiplayer.
The other change prevents fabric from making warnings about classes from the server not existing on the client and vice versa.