### PR TITLE
Network friendly with non modded client

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -5,12 +5,14 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.entity.player.Player;
 import net.minecraft.core.net.packet.Packet;
+import net.minecraft.core.net.packet.PacketCustomPayload;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.entity.player.PlayerServer;
 import org.jetbrains.annotations.NotNull;
 import turniplabs.halplibe.helper.EnvironmentHelper;
 
 import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -125,9 +127,12 @@ public final class NetworkHandler
 	}
 
 	@Environment(EnvType.SERVER)
-	public static void sendToPlayerMessagesConfiguration(Player player)
-	{
-		((PlayerServer)player).playerNetServerHandler.sendPacket(encode(new MessageIdsNetworkMessage(packetIds)));
+	public static void sendToPlayerMessagesConfiguration(Player player) {
+		((PlayerServer) player).playerNetServerHandler.sendPacket(
+				encode(
+						new MessageIdsNetworkMessage(packetIds)
+				).toPacketCustomPayload()
+		);
 	}
 
 	/**

--- a/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
@@ -7,6 +7,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.net.handler.PacketHandler;
 import net.minecraft.core.net.packet.Packet;
+import net.minecraft.core.net.packet.PacketCustomPayload;
 import org.jetbrains.annotations.NotNull;
 import turniplabs.halplibe.helper.EnvironmentHelper;
 import turniplabs.halplibe.mixin.accessors.PacketHandlerServerAccessor;
@@ -28,6 +29,16 @@ public class UniversalPacket extends Packet {
         this.buffer = new byte[0];
         this.writeIndex = 0;
         this.readIndex = 0;
+    }
+
+    public UniversalPacket(PacketCustomPayload packetCustomPayload) {
+        this.buffer = packetCustomPayload.data;
+        this.writeIndex = packetCustomPayload.data.length - 1;
+        this.readIndex = 0;
+    }
+
+    public PacketCustomPayload toPacketCustomPayload() {
+        return new PacketCustomPayload("HALPLIBE", buffer);
     }
 
     @Deprecated

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerClientMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerClientMixin.java
@@ -2,11 +2,13 @@ package turniplabs.halplibe.mixin;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.net.handler.PacketHandlerClient;
+import net.minecraft.core.net.packet.PacketCustomPayload;
 import net.minecraft.core.net.packet.PacketLogin;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.helper.network.UniversalPacket;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Mixin(value = PacketHandlerClient.class,remap = false)
@@ -14,5 +16,12 @@ public class PacketHandlerClientMixin {
     @Inject(method = "handleLogin", at = @At(value = "TAIL"))
     public void handleLogin(PacketLogin packet1login, CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::initNamespaces);
+    }
+
+    @Inject(method = "handleCustomPayload", at = @At(value = "TAIL"))
+    public void handleCustomPayload(PacketCustomPayload customPayloadPacket, CallbackInfo ci) {
+        if ("HALPLIBE".equals(customPayloadPacket.channel)) {
+            new UniversalPacket(customPayloadPacket).handlePacket((PacketHandlerClient) ((Object) this));
+        }
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerServerMixin.java
@@ -1,0 +1,19 @@
+package turniplabs.halplibe.mixin;
+
+import net.minecraft.core.net.packet.PacketCustomPayload;
+import net.minecraft.server.net.handler.PacketHandlerServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.helper.network.UniversalPacket;
+
+@Mixin(value = PacketHandlerServer.class,remap = false)
+public class PacketHandlerServerMixin {
+    @Inject(method = "handleCustomPayload", at = @At(value = "TAIL"))
+    public void handleCustomPayload(PacketCustomPayload customPayloadPacket, CallbackInfo ci) {
+        if ("HALPLIBE".equals(customPayloadPacket.channel)) {
+            new UniversalPacket(customPayloadPacket).handlePacket((PacketHandlerServer) ((Object) this));
+        }
+    }
+}

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -9,24 +9,25 @@
     "accessors.BlockAccessor",
     "accessors.BlocksAccessor",
     "accessors.LanguageAccessor",
+    "accessors.PacketHandlerServerAccessor",
     "accessors.WeightedRandomBagAccessor",
-    "accessors.WeightedRandomBagEntryAccessor",
-    "accessors.PacketHandlerServerAccessor"
+    "accessors.WeightedRandomBagEntryAccessor"
   ],
   "client": [
     "MinecraftMixin",
     "PacketHandlerClientMixin",
+    "accessors.EntityFireflyFXAccessor",
+    "accessors.EntityFXAccessor",
     "models.BlockColorDispatcherMixin",
     "models.BlockModelDispatcherMixin",
     "models.EntityRenderDispatcherMixin",
     "models.ItemModelDispatcherMixin",
-    "models.TileEntityRendererDispatcherMixin",
-    "accessors.EntityFireflyFXAccessor",
-    "accessors.EntityFXAccessor"
+    "models.TileEntityRendererDispatcherMixin"
   ],
   "server": [
     "MinecraftServerMixin",
-    "PacketHandlerLoginMixin"
+    "PacketHandlerLoginMixin",
+    "PacketHandlerServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
@UselessBullets on the discord discover my NetworkSystem make imposible to use halplibe on server without the client has also halplibe since my first `UniversalPacket` in `sendToPlayerMessagesConfiguration()` send a packet at id 88 which vanilla BTA will just panic :

![Screenshot From 2025-03-07 20-13-47](https://github.com/user-attachments/assets/e640766d-eef0-4db0-b667-4badb37ea398)

Since `UniversalPacket` and BTA  `PacketCustomPayload` are two class very similar this PR introduce a way to convert the `UniversalPacket` to  `PacketCustomPayload` and proper mixin to handle wrapped `UniversalPacket` inside `PacketCustomPayload`

With this new feature we can now send an already exiting `UniversalPacket` as a `PacketCustomPayload` for the cost of some extra bytes but this as the advantage for fixing the original issue I just need to convert the `sendToPlayerMessagesConfiguration()` `UniversalPacket` to a `PacketCustomPayload`and now if the client don't have halplibe, nothing will panic.

For the future may make possible from the halplibe consumer to choose if they want their message to be wrapped inside a `PacketCustomPayload` to prevent Bad packet ID but for now most mod that introduce extra network message should required the client to also have their mod installed.

Note: ***Please note this PR make old version of halplibe probably don't handle well the `sendToPlayerMessagesConfiguration()` if the server send the wrapped `PacketCustomPayload` to the client***