### PR TITLE
Add entrypoint for initializing Options

### DIFF
--- a/src/main/java/turniplabs/halplibe/mixin/AtlasStitcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/AtlasStitcherMixin.java
@@ -4,20 +4,14 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.render.texture.Texture;
 import net.minecraft.client.render.texture.stitcher.AtlasStitcher;
-import net.minecraft.client.render.texture.stitcher.IconCoordinate;
-import net.minecraft.core.util.collection.NamespaceID;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import turniplabs.halplibe.HalpLibe;
 
 import java.awt.image.BufferedImage;
-import java.util.Map;
 
 @SuppressWarnings("SuspiciousNameCombination")
 @Mixin(value = AtlasStitcher.class,remap = false)
-public class AtlasStitcherMixin extends Texture {
+public abstract class AtlasStitcherMixin extends Texture {
 
     @WrapOperation(method = "init", at = @At(value = "NEW", target = "(III)Ljava/awt/image/BufferedImage;"))
     public BufferedImage init(int width, int height, int imageType, Operation<BufferedImage> original){

--- a/src/main/java/turniplabs/halplibe/mixin/GameSettingsMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/GameSettingsMixin.java
@@ -1,0 +1,22 @@
+package turniplabs.halplibe.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.option.GameSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.util.OptionsInitEntrypoint;
+
+import java.io.File;
+
+@Mixin(value = GameSettings.class, remap = false)
+public abstract class GameSettingsMixin {
+    @Inject(method = "<init>", at = @At(value = "NEW", target = "(Ljava/io/File;Ljava/lang/String;)Ljava/io/File;"))
+    public void initOptions(Minecraft minecraft, File file, CallbackInfo ci) {
+        GameSettings settings = (GameSettings) (Object) this;
+
+        FabricLoader.getInstance().getEntrypoints("initOptions", OptionsInitEntrypoint.class).forEach(e -> e.initOptions(settings));
+    }
+}

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -8,19 +8,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.helper.network.NetworkHandler;
-
-import turniplabs.halplibe.util.BlockInitEntrypoint;
-import turniplabs.halplibe.util.ClientStartEntrypoint;
-import turniplabs.halplibe.util.GameStartEntrypoint;
-import turniplabs.halplibe.util.ItemInitEntrypoint;
-import turniplabs.halplibe.util.RecipeEntrypoint;
+import turniplabs.halplibe.util.*;
 
 @Mixin(
         value = Minecraft.class,
         remap = false
 )
 
-public class MinecraftMixin {
+public abstract class MinecraftMixin {
 
     @Inject(method = "startGame", at = @At(value = "INVOKE",target = "Lnet/minecraft/core/data/DataLoader;loadRecipesFromFile(Ljava/lang/String;)V", ordinal = 3, shift = At.Shift.AFTER))
     public void recipeEntrypoint(CallbackInfo ci){
@@ -43,12 +38,12 @@ public class MinecraftMixin {
 
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
     public void afterBlockInitEntrypoint(CallbackInfo ci) {
-        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);;
+        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
     }
 
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
     public void afterItemInitEntrypoint(CallbackInfo ci) {
-        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);;
+        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
     }
 
     @Inject(method = "printWrongJavaVersionInfo", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -15,7 +15,7 @@ import turniplabs.halplibe.util.ItemInitEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Mixin(value = MinecraftServer.class, remap = false)
-public class MinecraftServerMixin {
+public abstract class MinecraftServerMixin {
     @Shadow private static MinecraftServer instance;
 
     @Inject(method = "startServer", at = @At(value = "INVOKE",target = "Lnet/minecraft/core/data/DataLoader;loadRecipesFromFile(Ljava/lang/String;)V", ordinal = 3, shift = At.Shift.AFTER))
@@ -38,12 +38,12 @@ public class MinecraftServerMixin {
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
     public void afterBlockInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
-        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);;
+        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
     public void afterItemInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
-        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);;
+        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
     }
 
     /*

--- a/src/main/java/turniplabs/halplibe/mixin/MobCreeperMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MobCreeperMixin.java
@@ -7,7 +7,6 @@ import net.minecraft.core.entity.monster.MobMonster;
 import net.minecraft.core.item.ItemStack;
 import net.minecraft.core.world.World;
 import org.jetbrains.annotations.Nullable;
-import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerClientMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerClientMixin.java
@@ -12,7 +12,7 @@ import turniplabs.halplibe.helper.network.UniversalPacket;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Mixin(value = PacketHandlerClient.class,remap = false)
-public class PacketHandlerClientMixin {
+public abstract class PacketHandlerClientMixin {
     @Inject(method = "handleLogin", at = @At(value = "TAIL"))
     public void handleLogin(PacketLogin packet1login, CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::initNamespaces);

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerLoginMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerLoginMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import turniplabs.halplibe.helper.network.NetworkHandler;
 
 @Mixin(value = PacketHandlerLogin.class, remap = false)
-public class PacketHandlerLoginMixin {
+public abstract class PacketHandlerLoginMixin {
 		@Inject(method = "doLogin(Lnet/minecraft/core/net/packet/PacketLogin;)V", at = @At(value = "INVOKE",
 			target = "Lnet/minecraft/server/net/handler/PacketHandlerServer;sendPacket(Lnet/minecraft/core/net/packet/Packet;)V",
 			ordinal = 0, shift = At.Shift.AFTER),

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerServerMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.helper.network.UniversalPacket;
 
 @Mixin(value = PacketHandlerServer.class,remap = false)
-public class PacketHandlerServerMixin {
+public abstract class PacketHandlerServerMixin {
     @Inject(method = "handleCustomPayload", at = @At(value = "TAIL"))
     public void handleCustomPayload(PacketCustomPayload customPayloadPacket, CallbackInfo ci) {
         if ("HALPLIBE".equals(customPayloadPacket.channel)) {

--- a/src/main/java/turniplabs/halplibe/mixin/models/BlockColorDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/BlockColorDispatcherMixin.java
@@ -3,7 +3,6 @@ package turniplabs.halplibe.mixin.models;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.block.color.BlockColor;
 import net.minecraft.client.render.block.color.BlockColorDispatcher;
-import net.minecraft.client.render.item.model.ItemModelDispatcher;
 import net.minecraft.client.util.dispatch.Dispatcher;
 import net.minecraft.core.block.Block;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,13 +10,8 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.BlockBuilder;
 import turniplabs.halplibe.helper.ModelHelper;
 import turniplabs.halplibe.util.ModelEntrypoint;
-
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
 
 @Mixin(value = BlockColorDispatcher.class, remap = false)
 public abstract class BlockColorDispatcherMixin extends Dispatcher<Block<?>, BlockColor> {

--- a/src/main/java/turniplabs/halplibe/mixin/models/BlockModelDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/BlockModelDispatcherMixin.java
@@ -1,19 +1,14 @@
 package turniplabs.halplibe.mixin.models;
 
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.render.block.color.BlockColorDispatcher;
-import net.minecraft.client.render.block.model.BlockModel;
 import net.minecraft.client.render.block.model.BlockModelDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.BlockBuilder;
 import turniplabs.halplibe.helper.ModelHelper;
 import turniplabs.halplibe.util.ModelEntrypoint;
-import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Mixin(value = BlockModelDispatcher.class, remap = false)
 public abstract class BlockModelDispatcherMixin {

--- a/src/main/java/turniplabs/halplibe/mixin/models/EntityRenderDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/EntityRenderDispatcherMixin.java
@@ -2,9 +2,7 @@ package turniplabs.halplibe.mixin.models;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.EntityRenderDispatcher;
-import net.minecraft.client.render.block.color.BlockColorDispatcher;
 import net.minecraft.client.render.entity.EntityRenderer;
-import net.minecraft.core.entity.Entity;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -12,13 +10,10 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.EntityHelper;
 import turniplabs.halplibe.helper.ModelHelper;
 import turniplabs.halplibe.util.ModelEntrypoint;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
 
 @Mixin(value = EntityRenderDispatcher.class, remap = false)
 public abstract class EntityRenderDispatcherMixin {

--- a/src/main/java/turniplabs/halplibe/mixin/models/ItemModelDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/ItemModelDispatcherMixin.java
@@ -1,10 +1,8 @@
 package turniplabs.halplibe.mixin.models;
 
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.render.item.model.ItemModel;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/turniplabs/halplibe/mixin/models/TileEntityRendererDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/TileEntityRendererDispatcherMixin.java
@@ -2,7 +2,6 @@ package turniplabs.halplibe.mixin.models;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.TileEntityRenderDispatcher;
-import net.minecraft.client.render.item.model.ItemModelDispatcher;
 import net.minecraft.client.render.tileentity.TileEntityRenderer;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,7 +16,7 @@ import turniplabs.halplibe.util.ModelEntrypoint;
 import java.util.Map;
 
 @Mixin(value = TileEntityRenderDispatcher.class, remap = false)
-public class TileEntityRendererDispatcherMixin {
+public abstract class TileEntityRendererDispatcherMixin {
     @Shadow @Final private Map<Class<?>, TileEntityRenderer<?>> renderers;
 
     @Unique

--- a/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
@@ -1,0 +1,7 @@
+package turniplabs.halplibe.util;
+
+import net.minecraft.client.option.GameSettings;
+
+public interface OptionsInitEntrypoint {
+    void initOptions(GameSettings settings);
+}

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -15,6 +15,7 @@
   ],
   "client": [
     "AtlasStitcherMixin",
+    "GameSettingsMixin",
     "MinecraftMixin",
     "PacketHandlerClientMixin",
     "accessors.EntityFireflyFXAccessor",

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -9,7 +9,6 @@
     "accessors.BlockAccessor",
     "accessors.BlocksAccessor",
     "accessors.LanguageAccessor",
-    "accessors.PacketHandlerServerAccessor",
     "accessors.WeightedRandomBagAccessor",
     "accessors.WeightedRandomBagEntryAccessor"
   ],
@@ -27,6 +26,7 @@
     "models.TileEntityRendererDispatcherMixin"
   ],
   "server": [
+    "accessors.PacketHandlerServerAccessor",
     "MinecraftServerMixin",
     "PacketHandlerLoginMixin",
     "PacketHandlerServerMixin"


### PR DESCRIPTION
## Options Entrypoint https://github.com/Turnip-Labs/bta-halplibe/pull/74/commits/51bba4a6a88ca722400208d187dbaad306a15964
Since a `GameSettings` mixin is no longer needed to have `Option` instances properly registered, I propose adding an entrypoint so options are properly loaded without needing a mixin.

Usage:
```java
public class ExampleMod implements OptionsInitEntrypoint {

    public static OptionBoolean exampleOption;

      . . .

    @Override
    public void initOptions(GameSettings gameSettings) {
        exampleOption = new OptionBoolean(gameSettings, "exampleOption", false);
    }
}
```

## Fixes 
- https://github.com/Turnip-Labs/bta-halplibe/pull/74/commits/8e2c7608e161f50205a78f9c5cb8574169411f33 Removed unused imports and made mixin classes abstract 
- https://github.com/Turnip-Labs/bta-halplibe/pull/74/commits/06e200a1c646675ceea0365b865c1922ce77fbbb Fixed PacketHandlerServerAccessor being registered as a common mixin (this would display a class load warning) 
