### PR TITLE
Fix network corruption with bad processing of `UniversalPacket`

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -5,14 +5,12 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.entity.player.Player;
 import net.minecraft.core.net.packet.Packet;
-import net.minecraft.core.net.packet.PacketCustomPayload;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.entity.player.PlayerServer;
 import org.jetbrains.annotations.NotNull;
 import turniplabs.halplibe.helper.EnvironmentHelper;
 
 import java.lang.reflect.InvocationTargetException;
-import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Function;

--- a/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
@@ -45,7 +45,8 @@ public class UniversalPacket extends Packet {
     public void read(DataInputStream dis) throws IOException {
         final int length = dis.readInt();
         buffer = new byte[length];
-        writeIndex = dis.read(buffer, 0, length);
+        dis.readFully(buffer, 0, length);
+        writeIndex = length;
     }
 
     /**


### PR DESCRIPTION
Few weeks ago I got someone that try my first release of ComputerCraft for BTA. There was a report for this person where my mod did make some `Unexpected network error` but after further test from my side, I didn't understand which mod was doing this and couldn't reproduce this bug.

Today on my personal server with only CC and Halplibe, this bug reoccurred but this time I was able to debug and find a fix.

From the error message it was appearing one of the BTA Packet didn't do it's job and did a partial read, since every packet are kind aligned to the same stream, if one one of them don't read everything, everything is unaligned and now we got packet that try to decode garbage.

For better understanding I did create a build of Halplibe to see exactly what was send and receive from the `UniversalPacket` and I found those strange result :

Here the server send 5 `TurtleBrainClientMessage` and you can see the amount of byte the buffer is sending. Here nothing is strange.
![image](https://github.com/user-attachments/assets/f5243a02-9f3a-4197-aaf2-973c23d1ade3)

However on the client, we can clearly see one of those reception don't read the full content of what the server is sending which mean we left junk for other network process
![image](https://github.com/user-attachments/assets/bcc283ef-565d-4aa2-a9a2-82751a6d29b6)

It appear that `dis.read(buffer, 0, length)` or `dis.read(buffer)` don't guaranteed the read of length can be done in one operation since again it appear the stream don't fill with the necessary data in one write.

So after some try I found `dis.readFully(buffer, 0, length` fix everything and now I can't reproduce anymore on my server this error.