### PR TITLE
Add extra handles in `NetworkMessage` to filter execution Environment

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -94,6 +94,11 @@ public final class NetworkHandler
 		packetReaders.put( id, ( context, buf ) -> {
 			T result = decoder.apply( buf );
 			result.handle(context);
+			if (EnvironmentHelper.isServerEnvironment()) {
+				result.handleServerEnv(context);
+			} else {
+				result.handleClientEnv(context);
+			}
 		} );
 	}
 
@@ -115,7 +120,9 @@ public final class NetworkHandler
 	@Environment(EnvType.CLIENT)
 	private static void sendToPlayerLocal(NetworkMessage message)
 	{
-		message.handle(new NetworkMessage.NetworkContext(Minecraft.getMinecraft().thePlayer));
+		NetworkMessage.NetworkContext context = new NetworkMessage.NetworkContext(Minecraft.getMinecraft().thePlayer);
+		message.handle(context);
+		message.handleClientEnv(context);
 	}
 
 	@Environment(EnvType.SERVER)
@@ -228,11 +235,7 @@ public final class NetworkHandler
 		}
 
 		@Override
-		public void handle(NetworkContext context) {
-			if (EnvironmentHelper.isServerEnvironment()) {
-				return;
-			}
-
+		public void handleClientEnv(NetworkContext context) {
 			try {
 				NetworkHandler.packetReaders.clear();
 				NetworkHandler.packetIds.clear();

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
@@ -1,6 +1,9 @@
 package turniplabs.halplibe.helper.network;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.core.entity.player.Player;
+import turniplabs.halplibe.helper.EnvironmentHelper;
 
 import javax.annotation.Nonnull;
 
@@ -22,11 +25,32 @@ public interface NetworkMessage {
 	void decodeFromUniversalPacket(@Nonnull UniversalPacket packet );
 
 	/**
-	 * Handle this {@link NetworkMessage}.
+	 * Is called when this {@link NetworkMessage} is received.
+	 * This is common for both Env and is the recommended handle if you don't try to use object exclusive to a specific Env
 	 *
 	 * @param context An intermediary representation of Packet handler common on both Client and Server environment.
 	 */
-	void handle(NetworkContext context);
+	default void handle(NetworkContext context) {}
+
+	/**
+	 * Is called when this {@link NetworkMessage} is received with an extra check for preventing loading unavailable class for Server Env.
+	 * This is called after the common handle method.
+	 * NOTE: Single player doesn't execute this since Server Env is never available
+	 *
+	 * @param context An intermediary representation of Packet handler common on both Client and Server environment.
+	 */
+	@Environment(EnvType.SERVER)
+	default void handleServerEnv(NetworkContext context) {}
+
+	/**
+	 * Is called when this {@link NetworkMessage} is received with an extra check for preventing loading unavailable class for Client Env.
+	 * This is called after the common handle method.
+	 * NOTE: Single player does execute this since Client Env is always available
+	 *
+	 * @param context An intermediary representation of Packet handler common on both Client and Server environment.
+	 */
+	@Environment(EnvType.SERVER)
+	default void handleClientEnv(NetworkContext context) {}
 
 	class NetworkContext {
 		/**

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkMessage.java
@@ -49,7 +49,7 @@ public interface NetworkMessage {
 	 *
 	 * @param context An intermediary representation of Packet handler common on both Client and Server environment.
 	 */
-	@Environment(EnvType.SERVER)
+	@Environment(EnvType.CLIENT)
 	default void handleClientEnv(NetworkContext context) {}
 
 	class NetworkContext {


### PR DESCRIPTION
Often since in Java we can't load classes that have been striped, I find myself needed to create some condition branch that execute a single method since it's the only way to prevent wrongly unavailable import.

After the releasing of my first version of BTA CC, I found myself I did a terrible job of respecting the Client/Server Environement striping which lead to write in every method of my `NetworkMessage` extra handle for preventing the server loading the `Screen` class even there was some guard to preventing this.

![image](https://github.com/user-attachments/assets/ec57ea1e-bc20-4285-aca1-33279ce4c5ee)

This is kind of repetitive to have to have those condition on every `NetworkMessage` plus the needed to have two method for handling a simple GUI open so I decided to add two new methods on the Halplibe `NetworkMessage`

In this PR you will now found `handleClientEnv` and `handleServerEnv` which will be execute after the classic `handle` with a check to be sure we are not in the wrong environment which could lead to a crash.
Also now `handle` have a default implementation (it's an empty body) and so we can cleanly for opening a Screen just use `handleClientEnv`

![image](https://github.com/user-attachments/assets/b26d2f67-23b3-4c47-9337-4402b07e29a0)


*The usage in also explain in the `NetworkMessage` JavaDocs.*

Also this PR should not introduce breaking changes since `handle` is still called like before