### PR TITLE
Delay item stats initialization

### DIFF
--- a/src/main/java/turniplabs/halplibe/mixin/ItemsMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/ItemsMixin.java
@@ -1,0 +1,12 @@
+package turniplabs.halplibe.mixin;
+
+import net.minecraft.core.item.Items;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = Items.class ,remap = false)
+public abstract class ItemsMixin {
+    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;initStats()V"))
+    private static void delayInitStats() {}
+}

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.helper.network.NetworkHandler;
+import turniplabs.halplibe.mixin.accessors.ItemsAccessor;
 import turniplabs.halplibe.util.*;
 
 @Mixin(
@@ -44,6 +45,11 @@ public abstract class MinecraftMixin {
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
     public void afterItemInitEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
+    }
+
+    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/achievement/stat/StatList;init()V"))
+    public void initStats(CallbackInfo ci) {
+        ItemsAccessor.invokeInitStats();
     }
 
     @Inject(method = "printWrongJavaVersionInfo", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import turniplabs.halplibe.helper.network.NetworkHandler;
+import turniplabs.halplibe.mixin.accessors.ItemsAccessor;
 import turniplabs.halplibe.util.BlockInitEntrypoint;
 import turniplabs.halplibe.util.GameStartEntrypoint;
 import turniplabs.halplibe.util.ItemInitEntrypoint;
@@ -44,6 +45,11 @@ public abstract class MinecraftServerMixin {
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
     public void afterItemInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
         FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
+    }
+
+    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/achievement/stat/StatList;init()V"))
+    public void initStats(CallbackInfoReturnable<Boolean> cir) {
+        ItemsAccessor.invokeInitStats();
     }
 
     /*

--- a/src/main/java/turniplabs/halplibe/mixin/accessors/ItemsAccessor.java
+++ b/src/main/java/turniplabs/halplibe/mixin/accessors/ItemsAccessor.java
@@ -1,0 +1,11 @@
+package turniplabs.halplibe.mixin.accessors;
+
+import net.minecraft.core.item.Items;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(value = Items.class, remap = false)
+public interface ItemsAccessor {
+    @Invoker
+    static void invokeInitStats() {}
+}

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -5,9 +5,11 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "I18nMixin",
+    "ItemsMixin",
     "MobCreeperMixin",
     "accessors.BlockAccessor",
     "accessors.BlocksAccessor",
+    "accessors.ItemsAccessor",
     "accessors.LanguageAccessor",
     "accessors.WeightedRandomBagAccessor",
     "accessors.WeightedRandomBagEntryAccessor"


### PR DESCRIPTION
Fixes item stats not being initialized for Items added after vanilla Item initialization by delaying `Items#initStats`.