### PR TITLE
Improve NetworkMessage compatiiblities and reactivity

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -5,6 +5,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.entity.player.Player;
 import net.minecraft.core.net.packet.Packet;
+import net.minecraft.core.net.packet.PacketCustomPayload;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.entity.player.PlayerServer;
 import org.jetbrains.annotations.NotNull;
@@ -109,12 +110,31 @@ public final class NetworkHandler
 				.getClass();
 	}
 
-	private static UniversalPacket encode(NetworkMessage message )
+	/**
+	 * Convert a NetworkMessage to an UniversalPacket ready to be sent with BTA net handler.
+	 * <p>
+	 * (Prefer using the NetworkHandler send methods for single player message loop back).
+	 * <p>
+	 * Example: If you want to use a NetworkMessage for the `getDescriptionPacket` of a `TileEntity`.
+	 */
+	public static UniversalPacket generateNetworkMessagePacket(NetworkMessage message)
 	{
 		UniversalPacket buf = new UniversalPacket();
 		buf.writeShort( packetIds.get( message.getClass() ) );
 		message.encodeToUniversalPacket( buf );
 		return buf;
+	}
+
+	/**
+	 * Convert a NetworkMessage to a PacketCustomPayload ready to be sent with BTA net handler.
+	 * <p>
+	 * (Prefer using the NetworkHandler compatibilities send methods for single player message loop back).
+	 * <p>
+	 * Example: If you want to use a NetworkMessage for the `getDescriptionPacket` of a `TileEntity`.
+	 */
+	public static PacketCustomPayload generateCompatibilityNetworkMessagePacket(NetworkMessage message)
+	{
+		return generateNetworkMessagePacket(message).toPacketCustomPayload();
 	}
 
 	@Environment(EnvType.CLIENT)
@@ -126,37 +146,67 @@ public final class NetworkHandler
 	}
 
 	@Environment(EnvType.SERVER)
-	private static void sendToPlayerServer(Player player, NetworkMessage message)
+	private static void sendToPlayerServer(Player player, NetworkMessage message, boolean compatibility)
 	{
-		((PlayerServer)player).playerNetServerHandler.sendPacket(encode(message));
+		if (compatibility) {
+			((PlayerServer)player).playerNetServerHandler.sendPacket(generateCompatibilityNetworkMessagePacket(message));
+			return;
+		}
+		((PlayerServer)player).playerNetServerHandler.sendPacket(generateNetworkMessagePacket(message));
 	}
 
 	@Environment(EnvType.SERVER)
 	public static void sendToPlayerMessagesConfiguration(Player player) {
 		((PlayerServer) player).playerNetServerHandler.sendPacket(
-				encode(
+				generateCompatibilityNetworkMessagePacket(
 						new MessageIdsNetworkMessage(packetIds)
-				).toPacketCustomPayload()
+				)
 		);
 	}
 
 	/**
-	 * Send a NetworkMessage to a specific Player from the server
-	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 * Send a NetworkMessage to a specific Player from the server.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendCompatibilityToPlayer(Player, NetworkMessage)} if you are unsure your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
 	 */
 	@SuppressWarnings({"unused"})
-	public static void sendToPlayer(Player player, NetworkMessage message )
+	public static void sendToPlayer(Player player, NetworkMessage message)
 	{
 		if (!EnvironmentHelper.isServerEnvironment()){
 			sendToPlayerLocal(message);
 			return;
 		}
-		sendToPlayerServer(player, message);
+		sendToPlayerServer(player, message, false);
 	}
 
 	/**
-	 * Send a NetworkMessage to all Players from the server
-	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 * Send a NetworkMessage to a specific Player from the server.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will not be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendToPlayer(Player, NetworkMessage)} if you know your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
+	 */
+	@SuppressWarnings({"unused"})
+	public static void sendCompatibilityToPlayer(Player player, NetworkMessage message)
+	{
+		if (!EnvironmentHelper.isServerEnvironment()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		sendToPlayerServer(player, message, true);
+	}
+
+	/**
+	 * Send a NetworkMessage to all Players from the server.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendCompatibilityToAllPlayers(NetworkMessage)} if you are unsure your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
 	 */
 	@SuppressWarnings({"unused"})
 	public static void sendToAllPlayers( NetworkMessage message )
@@ -165,12 +215,34 @@ public final class NetworkHandler
 			sendToPlayerLocal(message);
 			return;
 		}
-		MinecraftServer.getInstance().playerList.sendPacketToAllPlayers(encode(message));
+		MinecraftServer.getInstance().playerList.sendPacketToAllPlayers(generateNetworkMessagePacket(message));
 	}
 
 	/**
-	 * Send a NetworkMessage to the Server from the player
-	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 * Send a NetworkMessage to all Players from the server.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will not be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendToAllPlayers(NetworkMessage)} if you know your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
+	 */
+	@SuppressWarnings({"unused"})
+	public static void sendCompatibilityToAllPlayers( NetworkMessage message )
+	{
+		if (!EnvironmentHelper.isServerEnvironment()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		MinecraftServer.getInstance().playerList.sendPacketToAllPlayers(generateCompatibilityNetworkMessagePacket(message));
+	}
+
+	/**
+	 * Send a NetworkMessage to the Server from the player.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendCompatibilityToServer(NetworkMessage)} if you are unsure your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
 	 */
 	@SuppressWarnings({"unused"})
 	@Environment( EnvType.CLIENT )
@@ -180,12 +252,35 @@ public final class NetworkHandler
 			sendToPlayerLocal(message);
 			return;
 		}
-		Minecraft.getMinecraft().getSendQueue().addToSendQueue(encode(message));
+		Minecraft.getMinecraft().getSendQueue().addToSendQueue(generateNetworkMessagePacket(message));
 	}
 
 	/**
-	 * Send a NetworkMessage to all Players around a block from the server
-	 * If we are in SinglePlayer this will skip encoding and directly call the message handle
+	 * Send a NetworkMessage to the Server from the player.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will not be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendToServer(NetworkMessage)} if you know your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
+	 */
+	@SuppressWarnings({"unused"})
+	@Environment( EnvType.CLIENT )
+	public static void sendCompatibilityToServer( NetworkMessage message )
+	{
+		if (EnvironmentHelper.isSinglePlayer()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		Minecraft.getMinecraft().getSendQueue().addToSendQueue(generateCompatibilityNetworkMessagePacket(message));
+	}
+
+	/**
+	 * Send a NetworkMessage to all Players around a block from the server.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendCompatibilityToAllAround(double, double, double, double, int, NetworkMessage)} if you are unsure your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
 	 */
 	@SuppressWarnings({"unused"})
 	public static void sendToAllAround(double x, double y, double z, double radius, int dimension, NetworkMessage message )
@@ -194,7 +289,25 @@ public final class NetworkHandler
 			sendToPlayerLocal(message);
 			return;
 		}
-		MinecraftServer.getInstance().playerList.sendPacketToPlayersAroundPoint(x, y, z, radius, dimension, encode(message));
+		MinecraftServer.getInstance().playerList.sendPacketToPlayersAroundPoint(x, y, z, radius, dimension, generateNetworkMessagePacket(message));
+	}
+
+	/**
+	 * Send a NetworkMessage to all Players around a block from the server.
+	 * <p>
+	 * If the receiver don't have Halplibe installed, the client will be kick for unrecognized Packet.
+	 * Prefer to use {@link NetworkHandler#sendToAllAround(double, double, double, double, int, NetworkMessage)} if you are unsure your receiver have Halplibe installed.
+	 * <p>
+	 * If we are in SinglePlayer this will skip encoding and directly call the message handle.
+	 */
+	@SuppressWarnings({"unused"})
+	public static void sendCompatibilityToAllAround(double x, double y, double z, double radius, int dimension, NetworkMessage message )
+	{
+		if (!EnvironmentHelper.isServerEnvironment()){
+			sendToPlayerLocal(message);
+			return;
+		}
+		MinecraftServer.getInstance().playerList.sendPacketToPlayersAroundPoint(x, y, z, radius, dimension, generateCompatibilityNetworkMessagePacket(message));
 	}
 
 	private static class MessageIdsNetworkMessage implements NetworkMessage{

--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -156,12 +156,8 @@ public final class NetworkHandler
 	}
 
 	@Environment(EnvType.SERVER)
-	public static void sendToPlayerMessagesConfiguration(Player player) {
-		((PlayerServer) player).playerNetServerHandler.sendPacket(
-				generateCompatibilityNetworkMessagePacket(
-						new MessageIdsNetworkMessage(packetIds)
-				)
-		);
+	public static PacketCustomPayload getMessagesConfigurationPacket() {
+		return generateCompatibilityNetworkMessagePacket(new MessageIdsNetworkMessage(packetIds));
 	}
 
 	/**

--- a/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/UniversalPacket.java
@@ -39,6 +39,11 @@ public class UniversalPacket extends Packet {
         this.readIndex = 0;
     }
 
+    /**
+     * Convert a UniversalPacket to a PacketCustomPayload.
+     * <p>
+     * This method is only intended to be used by the NetworkHandler since the MessageId will not be inserted for be sent to the network.
+     */
     public PacketCustomPayload toPacketCustomPayload() {
         return new PacketCustomPayload("HALPLIBE", buffer);
     }

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerLoginMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerLoginMixin.java
@@ -1,9 +1,12 @@
 package turniplabs.halplibe.mixin;
 
+import net.minecraft.core.net.NetworkManager;
 import net.minecraft.core.net.packet.PacketLogin;
+import net.minecraft.core.net.packet.PacketPreLogin;
 import net.minecraft.server.entity.player.PlayerServer;
 import net.minecraft.server.net.handler.PacketHandlerLogin;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -12,12 +15,11 @@ import turniplabs.halplibe.helper.network.NetworkHandler;
 
 @Mixin(value = PacketHandlerLogin.class, remap = false)
 public abstract class PacketHandlerLoginMixin {
-		@Inject(method = "doLogin(Lnet/minecraft/core/net/packet/PacketLogin;)V", at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/server/net/handler/PacketHandlerServer;sendPacket(Lnet/minecraft/core/net/packet/Packet;)V",
-			ordinal = 0, shift = At.Shift.AFTER),
-			locals = LocalCapture.CAPTURE_FAILHARD
-		)
-		public void doLogin(PacketLogin packetlogin, CallbackInfo ci, PlayerServer player) {
-			NetworkHandler.sendToPlayerMessagesConfiguration(player);
-		}
+	@Shadow
+	public NetworkManager netManager;
+
+	@Inject(method = "handleHandshake", at = @At(value = "HEAD"))
+	public void sendMessagesConfiguration(PacketPreLogin preLoginPacket, CallbackInfo ci) {
+		this.netManager.addToSendQueue(NetworkHandler.getMessagesConfigurationPacket());
 	}
+}


### PR DESCRIPTION
- [Add compatibility methods for sending NetworkMessage when halplibe is not installed on the receiver](https://github.com/Turnip-Labs/bta-halplibe/pull/82/commits/f457f830a4c5d0b8d93c935179f6bd4b6485c242)
- [Send NetworkMessages Configuration Packet before player begin login](https://github.com/Turnip-Labs/bta-halplibe/pull/82/commits/5b4cc8edf3e36809ac1a1add79ac3b1db80822ab)

Those two changes will not break existing mods and also don't required both client and server to have the same version. (After that's don't mean it's recommended to have mismatch version)