### PR TITLE
Make client warn when network message from server are missings

### DIFF
--- a/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
+++ b/src/main/java/turniplabs/halplibe/helper/network/NetworkHandler.java
@@ -9,6 +9,7 @@ import net.minecraft.core.net.packet.PacketCustomPayload;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.entity.player.PlayerServer;
 import org.jetbrains.annotations.NotNull;
+import turniplabs.halplibe.HalpLibe;
 import turniplabs.halplibe.helper.EnvironmentHelper;
 
 import java.lang.reflect.InvocationTargetException;
@@ -331,15 +332,16 @@ public final class NetworkHandler
 
 			final short size = packet.readShort();
 
-			try {
-				for (int i = 0; i < size; i++) {
-					final short id = packet.readShort();
-					final Class<?> messageClass = Class.forName(packet.readString());
+			for (int i = 0; i < size; i++) {
+				final short id = packet.readShort();
+				final String className = packet.readString();
+				try {
+					final Class<?> messageClass = Class.forName(className);
 
 					this.packetIds.put(messageClass, id);
+				} catch (ClassNotFoundException e) {
+					HalpLibe.LOGGER.warn("NetworkMessage {} from server couldn't be found on client", className);
 				}
-			} catch (ClassNotFoundException e) {
-				throw new RuntimeException(e);
 			}
 		}
 


### PR DESCRIPTION
When a player try to connect to a halplibe server and the server got some network message that the player don't have.
Currently Minecraft will show an error screen because the network message the client try to reconstruct don't exist.

This is an unwanted behavior since with network message with halplibe we want to be table to create network message on server even if client can't receive it for usecase as sending a compatible UniversalPacket or a deeper relation between specific client that the server know.

So this PR change the runtime error with a simple warning on the client when the client can't create the NetworkMessage. This mean the client could connect to the game without having every network message.

*Please note this don't mean you can always connect to a server without the client having the mod if for exemple the server send unknown recipes to the client*

Example :
<img width="1066" height="226" alt="Example" src="https://github.com/user-attachments/assets/ead9d336-b414-42ed-9547-490875c5df7a" />
