### PR TITLE
Add simple events & fixes for existing entrypoints

### DIFF
--- a/src/main/java/turniplabs/halplibe/event/Emitter.java
+++ b/src/main/java/turniplabs/halplibe/event/Emitter.java
@@ -1,0 +1,10 @@
+package turniplabs.halplibe.event;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused")
+public interface Emitter<LISTENER> {
+    void emit(@NonNull Consumer<LISTENER> consumer);
+}

--- a/src/main/java/turniplabs/halplibe/event/Event.java
+++ b/src/main/java/turniplabs/halplibe/event/Event.java
@@ -1,0 +1,8 @@
+package turniplabs.halplibe.event;
+
+import org.jspecify.annotations.NonNull;
+
+@SuppressWarnings("unused")
+public interface Event<LISTENER> {
+    void listen(@NonNull LISTENER listener);
+}

--- a/src/main/java/turniplabs/halplibe/event/EventSorted.java
+++ b/src/main/java/turniplabs/halplibe/event/EventSorted.java
@@ -1,9 +1,10 @@
 package turniplabs.halplibe.event;
 
 import org.jspecify.annotations.NonNull;
+import turniplabs.halplibe.util.dependency.Key;
 
 @SuppressWarnings("unused")
-public interface Event<LISTENER> {
-    void listen(@NonNull LISTENER listener);
+public interface EventSorted<LISTENER> {
+    void listen(@NonNull Key key, @NonNull LISTENER listener);
     void remove(@NonNull LISTENER listener);
 }

--- a/src/main/java/turniplabs/halplibe/event/IndirectEmitter.java
+++ b/src/main/java/turniplabs/halplibe/event/IndirectEmitter.java
@@ -1,0 +1,8 @@
+package turniplabs.halplibe.event;
+
+import org.jspecify.annotations.NonNull;
+
+@SuppressWarnings("unused")
+public interface IndirectEmitter<EMITTER> {
+    @NonNull EMITTER getEmitter();
+}

--- a/src/main/java/turniplabs/halplibe/event/ModListeners.java
+++ b/src/main/java/turniplabs/halplibe/event/ModListeners.java
@@ -1,0 +1,20 @@
+package turniplabs.halplibe.event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ModListeners<T> {
+    public final String modId;
+    public final List<Listener<T>> listeners;
+
+    public ModListeners(final String modId) {
+        this.modId = modId;
+        this.listeners = new ArrayList<>();
+    }
+
+    public void addListener(final String modId, final T listener) {
+        listeners.add(new Listener<>(modId, listener));
+    }
+
+    public record Listener<T>(String modId, T listener) {}
+}

--- a/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
@@ -7,21 +7,21 @@ import net.minecraft.client.render.TileEntityRenderDispatcher;
 import net.minecraft.client.render.block.color.BlockColorDispatcher;
 import net.minecraft.client.render.block.model.BlockModelDispatcher;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
-import turniplabs.halplibe.event.impl.BaseEvent;
-import turniplabs.halplibe.event.impl.SingleEvent;
+import turniplabs.halplibe.event.impl.SortedBaseEvent;
+import turniplabs.halplibe.event.impl.SortedSingleEvent;
 
 import java.util.function.Consumer;
 
 @Environment(EnvType.CLIENT)
 public final class ClientEvents {
-    public static final SingleEvent<Runnable> BEFORE_CLIENT_START = new SingleEvent<>("BeforeClientStart");
-    public static final SingleEvent<Runnable> AFTER_CLIENT_START = new SingleEvent<>("AfterClientStart");
+    public static final SortedSingleEvent<Runnable> BEFORE_CLIENT_START = new SortedSingleEvent<>("BeforeClientStart");
+    public static final SortedSingleEvent<Runnable> AFTER_CLIENT_START = new SortedSingleEvent<>("AfterClientStart");
 
-    public static final BaseEvent<Consumer<BlockModelDispatcher>> BLOCK_MODEL_RELOAD = new BaseEvent<>();
-    public static final BaseEvent<Consumer<ItemModelDispatcher>> ITEM_MODEL_RELOAD = new BaseEvent<>();
-    public static final BaseEvent<Consumer<EntityRendererDispatcher>> ENTITY_RENDERER_RELOAD = new BaseEvent<>();
-    public static final BaseEvent<Consumer<TileEntityRenderDispatcher>> TILE_ENTITY_RENDERER_RELOAD = new BaseEvent<>();
-    public static final BaseEvent<Consumer<BlockColorDispatcher>> BLOCK_COLOR_RELOAD = new BaseEvent<>();
+    public static final SortedBaseEvent<Consumer<BlockModelDispatcher>> BLOCK_MODEL_RELOAD = new SortedBaseEvent<>();
+    public static final SortedBaseEvent<Consumer<ItemModelDispatcher>> ITEM_MODEL_RELOAD = new SortedBaseEvent<>();
+    public static final SortedBaseEvent<Consumer<EntityRendererDispatcher>> ENTITY_RENDERER_RELOAD = new SortedBaseEvent<>();
+    public static final SortedBaseEvent<Consumer<TileEntityRenderDispatcher>> TILE_ENTITY_RENDERER_RELOAD = new SortedBaseEvent<>();
+    public static final SortedBaseEvent<Consumer<BlockColorDispatcher>> BLOCK_COLOR_RELOAD = new SortedBaseEvent<>();
 
     private ClientEvents() {}
 }

--- a/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
@@ -1,0 +1,27 @@
+package turniplabs.halplibe.event.defs;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.EntityRendererDispatcher;
+import net.minecraft.client.render.TileEntityRenderDispatcher;
+import net.minecraft.client.render.block.color.BlockColorDispatcher;
+import net.minecraft.client.render.block.model.BlockModelDispatcher;
+import net.minecraft.client.render.item.model.ItemModelDispatcher;
+import turniplabs.halplibe.event.impl.BaseEvent;
+import turniplabs.halplibe.event.impl.SingleEvent;
+
+import java.util.function.Consumer;
+
+@Environment(EnvType.CLIENT)
+public final class ClientEvents {
+    public static SingleEvent<Runnable> BEFORE_CLIENT_START = new SingleEvent<>("BeforeClientStart");
+    public static SingleEvent<Runnable> AFTER_CLIENT_START = new SingleEvent<>("AfterClientStart");
+
+    public static BaseEvent<Consumer<BlockModelDispatcher>> BLOCK_MODEL_RELOAD = new BaseEvent<>();
+    public static BaseEvent<Consumer<ItemModelDispatcher>> ITEM_MODEL_RELOAD = new BaseEvent<>();
+    public static BaseEvent<Consumer<EntityRendererDispatcher>> ENTITY_RENDERER_RELOAD = new BaseEvent<>();
+    public static BaseEvent<Consumer<TileEntityRenderDispatcher>> TILE_ENTITY_RENDERER_RELOAD = new BaseEvent<>();
+    public static BaseEvent<Consumer<BlockColorDispatcher>> BLOCK_COLOR_RELOAD = new BaseEvent<>();
+
+    private ClientEvents() {}
+}

--- a/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
@@ -14,14 +14,14 @@ import java.util.function.Consumer;
 
 @Environment(EnvType.CLIENT)
 public final class ClientEvents {
-    public static SingleEvent<Runnable> BEFORE_CLIENT_START = new SingleEvent<>("BeforeClientStart");
-    public static SingleEvent<Runnable> AFTER_CLIENT_START = new SingleEvent<>("AfterClientStart");
+    public static final SingleEvent<Runnable> BEFORE_CLIENT_START = new SingleEvent<>("BeforeClientStart");
+    public static final SingleEvent<Runnable> AFTER_CLIENT_START = new SingleEvent<>("AfterClientStart");
 
-    public static BaseEvent<Consumer<BlockModelDispatcher>> BLOCK_MODEL_RELOAD = new BaseEvent<>();
-    public static BaseEvent<Consumer<ItemModelDispatcher>> ITEM_MODEL_RELOAD = new BaseEvent<>();
-    public static BaseEvent<Consumer<EntityRendererDispatcher>> ENTITY_RENDERER_RELOAD = new BaseEvent<>();
-    public static BaseEvent<Consumer<TileEntityRenderDispatcher>> TILE_ENTITY_RENDERER_RELOAD = new BaseEvent<>();
-    public static BaseEvent<Consumer<BlockColorDispatcher>> BLOCK_COLOR_RELOAD = new BaseEvent<>();
+    public static final BaseEvent<Consumer<BlockModelDispatcher>> BLOCK_MODEL_RELOAD = new BaseEvent<>();
+    public static final BaseEvent<Consumer<ItemModelDispatcher>> ITEM_MODEL_RELOAD = new BaseEvent<>();
+    public static final BaseEvent<Consumer<EntityRendererDispatcher>> ENTITY_RENDERER_RELOAD = new BaseEvent<>();
+    public static final BaseEvent<Consumer<TileEntityRenderDispatcher>> TILE_ENTITY_RENDERER_RELOAD = new BaseEvent<>();
+    public static final BaseEvent<Consumer<BlockColorDispatcher>> BLOCK_COLOR_RELOAD = new BaseEvent<>();
 
     private ClientEvents() {}
 }

--- a/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
@@ -3,14 +3,14 @@ package turniplabs.halplibe.event.defs;
 import turniplabs.halplibe.event.impl.SingleEvent;
 
 public final class CommonEvents {
-    public static SingleEvent<Runnable> BEFORE_GAME_START = new SingleEvent<>("BeforeGameStart");
-    public static SingleEvent<Runnable> AFTER_GAME_START = new SingleEvent<>("AfterGameStart");
+    public static final SingleEvent<Runnable> BEFORE_GAME_START = new SingleEvent<>("BeforeGameStart");
+    public static final SingleEvent<Runnable> AFTER_GAME_START = new SingleEvent<>("AfterGameStart");
 
-    public static SingleEvent<Runnable> AFTER_BLOCK_INIT = new SingleEvent<>("AfterBlockInit");
-    public static SingleEvent<Runnable> AFTER_ITEM_INIT = new SingleEvent<>("AfterItemInit");
+    public static final SingleEvent<Runnable> AFTER_BLOCK_INIT = new SingleEvent<>("AfterBlockInit");
+    public static final SingleEvent<Runnable> AFTER_ITEM_INIT = new SingleEvent<>("AfterItemInit");
 
-    public static SingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SingleEvent<>("RecipesNamespaceInit");
-    public static SingleEvent<Runnable> RECIPES_READY = new SingleEvent<>("RecipesReady");
+    public static final SingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SingleEvent<>("RecipesNamespaceInit");
+    public static final SingleEvent<Runnable> RECIPES_READY = new SingleEvent<>("RecipesReady");
 
     private CommonEvents() {}
 }

--- a/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
@@ -1,0 +1,16 @@
+package turniplabs.halplibe.event.defs;
+
+import turniplabs.halplibe.event.impl.SingleEvent;
+
+public final class CommonEvents {
+    public static SingleEvent<Runnable> BEFORE_GAME_START = new SingleEvent<>("BeforeGameStart");
+    public static SingleEvent<Runnable> AFTER_GAME_START = new SingleEvent<>("AfterGameStart");
+
+    public static SingleEvent<Runnable> AFTER_BLOCK_INIT = new SingleEvent<>("AfterBlockInit");
+    public static SingleEvent<Runnable> AFTER_ITEM_INIT = new SingleEvent<>("AfterItemInit");
+
+    public static SingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SingleEvent<>("RecipesNamespaceInit");
+    public static SingleEvent<Runnable> RECIPES_READY = new SingleEvent<>("RecipesReady");
+
+    private CommonEvents() {}
+}

--- a/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
@@ -1,16 +1,16 @@
 package turniplabs.halplibe.event.defs;
 
-import turniplabs.halplibe.event.impl.SingleEvent;
+import turniplabs.halplibe.event.impl.SortedSingleEvent;
 
 public final class CommonEvents {
-    public static final SingleEvent<Runnable> BEFORE_GAME_START = new SingleEvent<>("BeforeGameStart");
-    public static final SingleEvent<Runnable> AFTER_GAME_START = new SingleEvent<>("AfterGameStart");
+    public static final SortedSingleEvent<Runnable> BEFORE_GAME_START = new SortedSingleEvent<>("BeforeGameStart");
+    public static final SortedSingleEvent<Runnable> AFTER_GAME_START = new SortedSingleEvent<>("AfterGameStart");
 
-    public static final SingleEvent<Runnable> AFTER_BLOCK_INIT = new SingleEvent<>("AfterBlockInit");
-    public static final SingleEvent<Runnable> AFTER_ITEM_INIT = new SingleEvent<>("AfterItemInit");
+    public static final SortedSingleEvent<Runnable> AFTER_BLOCK_INIT = new SortedSingleEvent<>("AfterBlockInit");
+    public static final SortedSingleEvent<Runnable> AFTER_ITEM_INIT = new SortedSingleEvent<>("AfterItemInit");
 
-    public static final SingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SingleEvent<>("RecipesNamespaceInit");
-    public static final SingleEvent<Runnable> RECIPES_READY = new SingleEvent<>("RecipesReady");
+    public static final SortedSingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SortedSingleEvent<>("RecipesNamespaceInit");
+    public static final SortedSingleEvent<Runnable> RECIPES_READY = new SortedSingleEvent<>("RecipesReady");
 
     private CommonEvents() {}
 }

--- a/src/main/java/turniplabs/halplibe/event/defs/ServerEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ServerEvents.java
@@ -6,8 +6,8 @@ import turniplabs.halplibe.event.impl.SingleEvent;
 
 @Environment(EnvType.SERVER)
 public final class ServerEvents {
-    public static SingleEvent<Runnable> BEFORE_SERVER_START = new SingleEvent<>("BeforeServerStart");
-    public static SingleEvent<Runnable> AFTER_SERVER_START = new SingleEvent<>("AfterServerStart");
+    public static final SingleEvent<Runnable> BEFORE_SERVER_START = new SingleEvent<>("BeforeServerStart");
+    public static final SingleEvent<Runnable> AFTER_SERVER_START = new SingleEvent<>("AfterServerStart");
 
     private ServerEvents() {}
 }

--- a/src/main/java/turniplabs/halplibe/event/defs/ServerEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ServerEvents.java
@@ -1,0 +1,13 @@
+package turniplabs.halplibe.event.defs;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import turniplabs.halplibe.event.impl.SingleEvent;
+
+@Environment(EnvType.SERVER)
+public final class ServerEvents {
+    public static SingleEvent<Runnable> BEFORE_SERVER_START = new SingleEvent<>("BeforeServerStart");
+    public static SingleEvent<Runnable> AFTER_SERVER_START = new SingleEvent<>("AfterServerStart");
+
+    private ServerEvents() {}
+}

--- a/src/main/java/turniplabs/halplibe/event/defs/ServerEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ServerEvents.java
@@ -2,12 +2,12 @@ package turniplabs.halplibe.event.defs;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import turniplabs.halplibe.event.impl.SingleEvent;
+import turniplabs.halplibe.event.impl.SortedSingleEvent;
 
 @Environment(EnvType.SERVER)
 public final class ServerEvents {
-    public static final SingleEvent<Runnable> BEFORE_SERVER_START = new SingleEvent<>("BeforeServerStart");
-    public static final SingleEvent<Runnable> AFTER_SERVER_START = new SingleEvent<>("AfterServerStart");
+    public static final SortedSingleEvent<Runnable> BEFORE_SERVER_START = new SortedSingleEvent<>("BeforeServerStart");
+    public static final SortedSingleEvent<Runnable> AFTER_SERVER_START = new SortedSingleEvent<>("AfterServerStart");
 
     private ServerEvents() {}
 }

--- a/src/main/java/turniplabs/halplibe/event/impl/BaseEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/BaseEvent.java
@@ -21,4 +21,9 @@ public class BaseEvent<L> implements Event<L>, Emitter<L> {
     public void listen(@NonNull final L listener) {
         listeners.add(listener);
     }
+
+    @Override
+    public void remove(@NonNull final L listener) {
+        listeners.remove(listener);
+    }
 }

--- a/src/main/java/turniplabs/halplibe/event/impl/BaseEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/BaseEvent.java
@@ -13,12 +13,12 @@ public class BaseEvent<L> implements Event<L>, Emitter<L> {
     protected final @NonNull List<L> listeners = new ArrayList<>();
 
     @Override
-    public void emit(@NonNull Consumer<L> consumer) {
+    public void emit(@NonNull final Consumer<L> consumer) {
         listeners.forEach(consumer);
     }
 
     @Override
-    public void listen(@NonNull L listener) {
+    public void listen(@NonNull final L listener) {
         listeners.add(listener);
     }
 }

--- a/src/main/java/turniplabs/halplibe/event/impl/BaseEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/BaseEvent.java
@@ -1,0 +1,24 @@
+package turniplabs.halplibe.event.impl;
+
+import org.jspecify.annotations.NonNull;
+import turniplabs.halplibe.event.Emitter;
+import turniplabs.halplibe.event.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused")
+public class BaseEvent<L> implements Event<L>, Emitter<L> {
+    protected final @NonNull List<L> listeners = new ArrayList<>();
+
+    @Override
+    public void emit(@NonNull Consumer<L> consumer) {
+        listeners.forEach(consumer);
+    }
+
+    @Override
+    public void listen(@NonNull L listener) {
+        listeners.add(listener);
+    }
+}

--- a/src/main/java/turniplabs/halplibe/event/impl/CustomEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/CustomEvent.java
@@ -10,17 +10,17 @@ import java.util.function.Function;
 
 @SuppressWarnings("unused")
 public class CustomEvent<L, E> implements IndirectEmitter<E>, Event<L> {
-    protected final @NonNull Function<List<L>, E> emitter;
+    protected final @NonNull E emitter;
     protected final @NonNull List<L> listeners;
 
     public CustomEvent(@NonNull final Function<List<L>, E> emitter) {
-        this.emitter = emitter;
         this.listeners = new ArrayList<>();
+        this.emitter = emitter.apply(this.listeners);
     }
 
     @Override
     public @NonNull E getEmitter() {
-        return emitter.apply(listeners);
+        return emitter;
     }
 
     @Override

--- a/src/main/java/turniplabs/halplibe/event/impl/CustomEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/CustomEvent.java
@@ -27,4 +27,9 @@ public class CustomEvent<L, E> implements IndirectEmitter<E>, Event<L> {
     public void listen(@NonNull final L listener) {
         listeners.add(listener);
     }
+
+    @Override
+    public void remove(@NonNull final L listener) {
+        listeners.remove(listener);
+    }
 }

--- a/src/main/java/turniplabs/halplibe/event/impl/CustomEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/CustomEvent.java
@@ -1,0 +1,30 @@
+package turniplabs.halplibe.event.impl;
+
+import org.jspecify.annotations.NonNull;
+import turniplabs.halplibe.event.Event;
+import turniplabs.halplibe.event.IndirectEmitter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+@SuppressWarnings("unused")
+public class CustomEvent<L, E> implements IndirectEmitter<E>, Event<L> {
+    protected final @NonNull Function<List<L>, E> emitter;
+    protected final @NonNull List<L> listeners;
+
+    public CustomEvent(@NonNull final Function<List<L>, E> emitter) {
+        this.emitter = emitter;
+        this.listeners = new ArrayList<>();
+    }
+
+    @Override
+    public @NonNull E getEmitter() {
+        return emitter.apply(listeners);
+    }
+
+    @Override
+    public void listen(@NonNull final L listener) {
+        listeners.add(listener);
+    }
+}

--- a/src/main/java/turniplabs/halplibe/event/impl/SingleEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/SingleEvent.java
@@ -23,7 +23,7 @@ public class SingleEvent<L> implements Event<L>, Emitter<L> {
     @Override
     public void emit(@NonNull final Consumer<L> consumer) {
         if (listeners == null) {
-            HalpLibe.LOGGER.warn("Attempted to call '{}' SingleEvent, but it was already consumed.", name);
+            HalpLibe.LOGGER.warn("Attempted to call '{}' SingleEvent multiple times.", name);
             return;
         }
 
@@ -39,5 +39,10 @@ public class SingleEvent<L> implements Event<L>, Emitter<L> {
         }
 
         listeners.add(listener);
+    }
+
+    @Override
+    public void remove(@NonNull final L listener) {
+        if (listeners != null) listeners.remove(listener);
     }
 }

--- a/src/main/java/turniplabs/halplibe/event/impl/SingleEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/SingleEvent.java
@@ -1,0 +1,43 @@
+package turniplabs.halplibe.event.impl;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import turniplabs.halplibe.HalpLibe;
+import turniplabs.halplibe.event.Emitter;
+import turniplabs.halplibe.event.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused")
+public class SingleEvent<L> implements Event<L>, Emitter<L> {
+    protected final String name;
+    protected @Nullable List<L> listeners;
+
+    public SingleEvent(@NonNull final String name) {
+        this.name = name;
+        this.listeners = new ArrayList<>();
+    }
+
+    @Override
+    public void emit(@NonNull final Consumer<L> consumer) {
+        if (listeners == null) {
+            HalpLibe.LOGGER.warn("Attempted to call '{}' SingleEvent, but it was already consumed.", name);
+            return;
+        }
+
+        listeners.forEach(consumer);
+        listeners = null;
+    }
+
+    @Override
+    public void listen(@NonNull final L listener) {
+        if (listeners == null) {
+            HalpLibe.LOGGER.warn("Attempted to add listener to '{}' SingleEvent too late.", name);
+            return;
+        }
+
+        listeners.add(listener);
+    }
+}

--- a/src/main/java/turniplabs/halplibe/event/impl/SortedBaseEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/SortedBaseEvent.java
@@ -1,0 +1,51 @@
+package turniplabs.halplibe.event.impl;
+
+import org.jspecify.annotations.NonNull;
+import turniplabs.halplibe.event.Emitter;
+import turniplabs.halplibe.event.EventSorted;
+import turniplabs.halplibe.event.ModListeners;
+import turniplabs.halplibe.event.utils.EventUtils;
+import turniplabs.halplibe.util.dependency.Key;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused")
+public class SortedBaseEvent<L> implements EventSorted<L>, Emitter<L> {
+    protected final @NonNull List<ModListeners<L>> listeners = new ArrayList<>();
+    protected boolean isSorted;
+
+    public SortedBaseEvent() {
+        this.listeners.add(new ModListeners<>("bta"));
+    }
+
+    @Override
+    public void emit(@NonNull final Consumer<L> consumer) {
+
+        if (!isSorted) {
+            // The first element should always be BTA
+            EventUtils.sortBFS(listeners, listeners.get(0));
+            isSorted = true;
+        }
+
+        listeners.forEach(ml -> ml.listeners.forEach(l -> consumer.accept(l.listener())));
+    }
+
+    @Override
+    public void listen(@NonNull final Key key, @NonNull final L listener) {
+        final int prevSize = listeners.size();
+        final ModListeners<L> ml = EventUtils.getListenersOf(listeners, key.dependsOn());
+        if (prevSize != listeners.size()) isSorted = false;
+
+        ml.addListener(key.modId(), listener);
+    }
+
+    @Override
+    public void remove(@NonNull final L listener) {
+        for (int i = 0; i < listeners.size(); ++i) {
+            final ModListeners<L> ml = listeners.get(i);
+            if (ml.listeners.removeIf(l -> l.listener() == listener)) return;
+        }
+    }
+}

--- a/src/main/java/turniplabs/halplibe/event/impl/SortedCustomEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/SortedCustomEvent.java
@@ -1,0 +1,52 @@
+package turniplabs.halplibe.event.impl;
+
+import org.jspecify.annotations.NonNull;
+import turniplabs.halplibe.event.EventSorted;
+import turniplabs.halplibe.event.IndirectEmitter;
+import turniplabs.halplibe.event.ModListeners;
+import turniplabs.halplibe.event.utils.EventUtils;
+import turniplabs.halplibe.util.dependency.Key;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+@SuppressWarnings("unused")
+public class SortedCustomEvent<L, E> implements EventSorted<L>, IndirectEmitter<E> {
+    protected final @NonNull E emitter;
+    protected final @NonNull List<ModListeners<L>> listeners;
+    protected boolean isSorted;
+
+    public SortedCustomEvent(@NonNull final Function<List<ModListeners<L>>, E> emitter) {
+        this.listeners = new ArrayList<>();
+        this.emitter = emitter.apply(this.listeners);
+        listeners.add(new ModListeners<>("bta"));
+    }
+
+    @Override
+    public @NonNull E getEmitter() {
+        if (!isSorted) {
+            // The first element should always be BTA
+            EventUtils.sortBFS(listeners, listeners.get(0));
+            isSorted = true;
+        }
+        return emitter;
+    }
+
+    @Override
+    public void listen(@NonNull final Key key, @NonNull final L listener) {
+        final int prevSize = listeners.size();
+        final ModListeners<L> ml = EventUtils.getListenersOf(listeners, key.dependsOn());
+        if (prevSize != listeners.size()) isSorted = false;
+
+        ml.addListener(key.modId(), listener);
+    }
+
+    @Override
+    public void remove(@NonNull final L listener) {
+        for (int i = 0; i < listeners.size(); ++i) {
+            final ModListeners<L> ml = listeners.get(i);
+            if (ml.listeners.removeIf(l -> l.listener() == listener)) return;
+        }
+    }
+}

--- a/src/main/java/turniplabs/halplibe/event/impl/SortedSingleEvent.java
+++ b/src/main/java/turniplabs/halplibe/event/impl/SortedSingleEvent.java
@@ -1,0 +1,61 @@
+package turniplabs.halplibe.event.impl;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import turniplabs.halplibe.HalpLibe;
+import turniplabs.halplibe.event.Emitter;
+import turniplabs.halplibe.event.EventSorted;
+import turniplabs.halplibe.event.ModListeners;
+import turniplabs.halplibe.event.utils.EventUtils;
+import turniplabs.halplibe.util.dependency.Key;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@SuppressWarnings("unused")
+public class SortedSingleEvent<L> implements EventSorted<L>, Emitter<L> {
+    protected final String name;
+    protected @Nullable List<ModListeners<L>> listeners;
+
+    public SortedSingleEvent(@NonNull final String name) {
+        this.name = name;
+        this.listeners = new ArrayList<>();
+        this.listeners.add(new ModListeners<>("bta"));
+    }
+
+    @Override
+    public void emit(@NonNull final Consumer<L> consumer) {
+        if (listeners == null) {
+            HalpLibe.LOGGER.warn("Attempted to call '{}' SingleEvent multiple times.", name);
+            return;
+        }
+
+        // The first element should always be BTA
+        EventUtils.sortBFS(listeners, listeners.get(0));
+
+        listeners.forEach(ml -> ml.listeners.forEach(l -> consumer.accept(l.listener())));
+        listeners = null;
+    }
+
+    @Override
+    public void listen(@NonNull final Key key, @NonNull final L listener) {
+        if (listeners == null) {
+            HalpLibe.LOGGER.warn("Attempted to add listener to '{}' SingleEvent too late.", name);
+            return;
+        }
+
+        final ModListeners<L> ml = EventUtils.getListenersOf(listeners, key.dependsOn());
+        ml.addListener(key.modId(), listener);
+    }
+
+    @Override
+    public void remove(@NonNull final L listener) {
+        if (listeners == null) return;
+
+        for (int i = 0; i < listeners.size(); ++i) {
+            final ModListeners<L> ml = listeners.get(i);
+            if (ml.listeners.removeIf(l -> l.listener() == listener)) return;
+        }
+    }
+}

--- a/src/main/java/turniplabs/halplibe/event/utils/EventUtils.java
+++ b/src/main/java/turniplabs/halplibe/event/utils/EventUtils.java
@@ -1,0 +1,55 @@
+package turniplabs.halplibe.event.utils;
+
+import org.jspecify.annotations.NullMarked;
+import turniplabs.halplibe.event.ModListeners;
+import turniplabs.halplibe.util.collections.CollectionUtils;
+
+import java.util.*;
+
+@NullMarked
+public final class EventUtils {
+
+    /**
+     * Executes a breadth-first search on a list of listeners, dropping any unreachable nodes.
+     * The provided list is assumed to contain no duplicate ModListener entries.
+     * <br><br>
+     * Dev Note: Circular dependencies are currently impossible, if multiple dependencies are ever allowed
+     * this method will have to be replaced.
+     */
+    public static <T> void sortBFS(final List<ModListeners<T>> listeners, final ModListeners<T> root) {
+        if (listeners.isEmpty()) return;
+
+        final Map<String, ModListeners<T>> map = CollectionUtils.mapCollection(listeners, new HashMap<>(), l -> l.modId);
+        listeners.clear();
+
+        final Deque<String> modIdQueue = new ArrayDeque<>();
+        modIdQueue.add(root.modId);
+
+        while (!modIdQueue.isEmpty()) {
+            final String nextId = modIdQueue.poll();
+
+            final ModListeners<T> ml = map.remove(nextId);
+            if (ml == null) continue;
+
+            listeners.add(ml);
+            ml.listeners.forEach(l -> modIdQueue.add(l.modId()));
+        }
+    }
+
+    /**
+     * Finds the first listener array matching modId, or adds a new listener array to the list and returns it.
+     */
+    public static <T> ModListeners<T> getListenersOf(final List<ModListeners<T>> listeners, final String modId) {
+        for (int i = 0; i < listeners.size(); ++i) {
+            final ModListeners<T> ml = listeners.get(i);
+            if (ml.modId.equals(modId)) return ml;
+        }
+
+        final ModListeners<T> newListeners = new ModListeners<>(modId);
+        listeners.add(newListeners);
+
+        return newListeners;
+    }
+
+    private EventUtils() {}
+}

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -15,6 +15,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.HalpLibe;
+import turniplabs.halplibe.event.defs.ClientEvents;
+import turniplabs.halplibe.event.defs.CommonEvents;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryRegistry;
 import turniplabs.halplibe.helper.network.NetworkHandler;
 import turniplabs.halplibe.mixin.accessors.ItemsAccessor;
@@ -35,13 +37,17 @@ public abstract class MinecraftMixin {
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/data/DataLoader;loadRecipesFromFile(Ljava/lang/String;)V", ordinal = 3, shift = At.Shift.AFTER))
     public void recipeEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::initNamespaces);
+        CommonEvents.RECIPES_NAMESPACE_INIT.emit(Runnable::run);
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::onRecipesReady);
+        CommonEvents.RECIPES_READY.emit(Runnable::run);
     }
 
     @Inject(method = "startGame", at = @At("HEAD"))
     public void beforeGameStartEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("beforeClientStart", ClientStartEntrypoint.class).forEach(ClientStartEntrypoint::beforeClientStart);
         FabricLoader.getInstance().getEntrypoints("beforeGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::beforeGameStart);
+        ClientEvents.BEFORE_CLIENT_START.emit(Runnable::run);
+        CommonEvents.BEFORE_GAME_START.emit(Runnable::run);
     }
 
     @Inject(method = "startGame", at = @At("TAIL"))
@@ -51,6 +57,8 @@ public abstract class MinecraftMixin {
         NetworkHandler.internalNetworkHandlerSetup();
         FabricLoader.getInstance().getEntrypoints("afterGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::afterGameStart);
         FabricLoader.getInstance().getEntrypoints("afterClientStart", ClientStartEntrypoint.class).forEach(ClientStartEntrypoint::afterClientStart);
+        ClientEvents.AFTER_CLIENT_START.emit(Runnable::run);
+        CommonEvents.AFTER_GAME_START.emit(Runnable::run);
         if (HalpLibe.CONFIG.getBoolean("recoveryMode")) {
             PopupScreen popup = new PopupBuilder(this.currentScreen, 246)
                     .withLabelLiteral(I18n.getInstance().translateKey("halplibe.recoveryMode"))
@@ -69,11 +77,13 @@ public abstract class MinecraftMixin {
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
     public void afterBlockInitEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
+        CommonEvents.AFTER_BLOCK_INIT.emit(Runnable::run);
     }
 
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
     public void afterItemInitEntrypoint(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
+        CommonEvents.AFTER_ITEM_INIT.emit(Runnable::run);
     }
 
     @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/achievement/stat/StatList;init()V"))

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -12,6 +12,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import turniplabs.halplibe.HalpLibe;
+import turniplabs.halplibe.event.defs.CommonEvents;
+import turniplabs.halplibe.event.defs.ServerEvents;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryRegistry;
 import turniplabs.halplibe.helper.network.NetworkHandler;
 import turniplabs.halplibe.mixin.accessors.ItemsAccessor;
@@ -29,7 +31,9 @@ public abstract class MinecraftServerMixin {
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/data/DataLoader;loadRecipesFromFile(Ljava/lang/String;)V", ordinal = 3, shift = At.Shift.AFTER))
     public void recipeEntrypoint(CallbackInfoReturnable<Boolean> cir) {
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::initNamespaces);
+        CommonEvents.RECIPES_NAMESPACE_INIT.emit(Runnable::run);
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::onRecipesReady);
+        CommonEvents.RECIPES_READY.emit(Runnable::run);
     }
 
     @Inject(method = "startServer", at = @At("HEAD"))
@@ -38,6 +42,8 @@ public abstract class MinecraftServerMixin {
         Global.isServer = true;
         NetworkHandler.internalNetworkHandlerSetup();
         FabricLoader.getInstance().getEntrypoints("beforeGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::beforeGameStart);
+        ServerEvents.BEFORE_SERVER_START.emit(Runnable::run);
+        CommonEvents.BEFORE_GAME_START.emit(Runnable::run);
     }
 
     @Inject(method = "startServer", at = @At("TAIL"))
@@ -45,16 +51,20 @@ public abstract class MinecraftServerMixin {
         CreativeInventoryRegistry.INSTANCE.bakeAll();
 
         FabricLoader.getInstance().getEntrypoints("afterGameStart", GameStartEntrypoint.class).forEach(GameStartEntrypoint::afterGameStart);
+        ServerEvents.AFTER_SERVER_START.emit(Runnable::run);
+        CommonEvents.AFTER_GAME_START.emit(Runnable::run);
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.AFTER))
     public void afterBlockInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
         FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
+        CommonEvents.AFTER_BLOCK_INIT.emit(Runnable::run);
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.AFTER))
     public void afterItemInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
         FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
+        CommonEvents.AFTER_ITEM_INIT.emit(Runnable::run);
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/achievement/stat/StatList;init()V"))

--- a/src/main/java/turniplabs/halplibe/mixin/models/BlockColorDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/BlockColorDispatcherMixin.java
@@ -5,25 +5,27 @@ import net.minecraft.client.render.block.color.BlockColor;
 import net.minecraft.client.render.block.color.BlockColorDispatcher;
 import net.minecraft.client.util.dispatch.Dispatcher;
 import net.minecraft.core.block.Block;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.ModelHelper;
+import turniplabs.halplibe.event.defs.ClientEvents;
 import turniplabs.halplibe.util.ModelEntrypoint;
 
 @Mixin(value = BlockColorDispatcher.class)
 public abstract class BlockColorDispatcherMixin extends Dispatcher<Block<?>, BlockColor> {
 
-    @Unique
-    private final BlockColorDispatcher thisAs = (BlockColorDispatcher) (Object) this;
+    @Shadow
+    @Final
+    private static BlockColorDispatcher instance;
 
-    @Inject(method = "<init>()V", at = @At("TAIL"))
+    @Inject(method = "reload", at = @At("TAIL"))
     private void addQueuedModels(CallbackInfo ci) {
-        ModelHelper.blockColorDispatcher = thisAs;
         FabricLoader.getInstance()
                 .getEntrypoints("initModels", ModelEntrypoint.class)
-                .forEach(e -> e.initBlockColors(thisAs));
+                .forEach(e -> e.initBlockColors(instance));
+        ClientEvents.BLOCK_COLOR_RELOAD.emit(consumer -> consumer.accept(instance));
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/models/BlockModelDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/BlockModelDispatcherMixin.java
@@ -3,24 +3,24 @@ package turniplabs.halplibe.mixin.models;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.block.model.BlockModelDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.ModelHelper;
+import turniplabs.halplibe.event.defs.ClientEvents;
 import turniplabs.halplibe.util.ModelEntrypoint;
 
 @Mixin(value = BlockModelDispatcher.class)
 public abstract class BlockModelDispatcherMixin {
 
-    @Unique
-    private final BlockModelDispatcher thisAs = (BlockModelDispatcher) (Object) this;
+    @Shadow
+    private static BlockModelDispatcher instance;
 
-    @Inject(method = "<init>()V", at = @At("TAIL"))
+    @Inject(method = "reload", at = @At("TAIL"))
     private void addQueuedModels(CallbackInfo ci) {
-        ModelHelper.blockModelDispatcher = thisAs;
         FabricLoader.getInstance()
                 .getEntrypoints("initModels", ModelEntrypoint.class)
-                .forEach(e -> e.initBlockModels(thisAs));
+                .forEach(e -> e.initBlockModels(instance));
+        ClientEvents.BLOCK_MODEL_RELOAD.emit(consumer -> consumer.accept(instance));
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/models/EntityRendererDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/EntityRendererDispatcherMixin.java
@@ -2,25 +2,29 @@ package turniplabs.halplibe.mixin.models;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.EntityRendererDispatcher;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.ModelHelper;
+import turniplabs.halplibe.event.defs.ClientEvents;
 import turniplabs.halplibe.util.ModelEntrypoint;
 
 @Mixin(value = EntityRendererDispatcher.class)
 public abstract class EntityRendererDispatcherMixin {
 
-    @Unique
-    private final EntityRendererDispatcher thisAs = (EntityRendererDispatcher) (Object) this;
+    @Shadow
+    @Final
+    @NotNull
+    public static EntityRendererDispatcher instance;
 
     @Inject(method = "reload", at = @At(value = "TAIL"))
     private void addQueuedModels(CallbackInfo ci) {
-        ModelHelper.entityRendererDispatcher = thisAs;
         FabricLoader.getInstance()
                 .getEntrypoints("initModels", ModelEntrypoint.class)
-                .forEach(e -> e.initEntityModels(thisAs));
+                .forEach(e -> e.initEntityModels(instance));
+        ClientEvents.ENTITY_RENDERER_RELOAD.emit(consumer -> consumer.accept(instance));
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/models/ItemModelDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/ItemModelDispatcherMixin.java
@@ -3,24 +3,24 @@ package turniplabs.halplibe.mixin.models;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.ModelHelper;
+import turniplabs.halplibe.event.defs.ClientEvents;
 import turniplabs.halplibe.util.ModelEntrypoint;
 
 @Mixin(value = ItemModelDispatcher.class)
 public abstract class ItemModelDispatcherMixin {
 
-    @Unique
-    private final ItemModelDispatcher thisAs = (ItemModelDispatcher) (Object) this;
+    @Shadow
+    private static ItemModelDispatcher instance;
 
-    @Inject(method = "<init>()V", at = @At("TAIL"))
+    @Inject(method = "reload", at = @At("TAIL"))
     private void addQueuedModels(CallbackInfo ci) {
-        ModelHelper.itemModelDispatcher = thisAs;
         FabricLoader.getInstance()
                 .getEntrypoints("initModels", ModelEntrypoint.class)
-                .forEach(e -> e.initItemModels(thisAs));
+                .forEach(e -> e.initItemModels(instance));
+        ClientEvents.ITEM_MODEL_RELOAD.emit(consumer -> consumer.accept(instance));
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/models/TileEntityRendererDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/models/TileEntityRendererDispatcherMixin.java
@@ -2,25 +2,29 @@ package turniplabs.halplibe.mixin.models;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.render.TileEntityRenderDispatcher;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import turniplabs.halplibe.helper.ModelHelper;
+import turniplabs.halplibe.event.defs.ClientEvents;
 import turniplabs.halplibe.util.ModelEntrypoint;
 
 @Mixin(value = TileEntityRenderDispatcher.class)
 public abstract class TileEntityRendererDispatcherMixin {
 
-    @Unique
-    private final TileEntityRenderDispatcher thisAs = (TileEntityRenderDispatcher) (Object) this;
+    @Shadow
+    @Final
+    @NotNull
+    public static TileEntityRenderDispatcher instance;
 
     @Inject(method = "reload", at = @At(value = "TAIL"))
     private void addQueuedModels(CallbackInfo ci) {
-        ModelHelper.tileEntityRenderDispatcher = thisAs;
         FabricLoader.getInstance()
                 .getEntrypoints("initModels", ModelEntrypoint.class)
-                .forEach(e -> e.initTileEntityModels(thisAs));
+                .forEach(e -> e.initTileEntityModels(instance));
+        ClientEvents.TILE_ENTITY_RENDERER_RELOAD.emit(consumer -> consumer.accept(instance));
     }
 }

--- a/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 public interface BlockInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code afterBlockInit}.

--- a/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 public interface BlockInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code afterBlockInit}.

--- a/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/BlockInitEntrypoint.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.util;
 
+@Deprecated
 public interface BlockInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code afterBlockInit}.

--- a/src/main/java/turniplabs/halplibe/util/ClientStartEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ClientStartEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 public interface ClientStartEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code beforeClientStart}.

--- a/src/main/java/turniplabs/halplibe/util/ClientStartEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ClientStartEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-
+@Deprecated
 public interface ClientStartEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code beforeClientStart}.

--- a/src/main/java/turniplabs/halplibe/util/ClientStartEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ClientStartEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 public interface ClientStartEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code beforeClientStart}.

--- a/src/main/java/turniplabs/halplibe/util/GameStartEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/GameStartEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 public interface GameStartEntrypoint {
 
     /**

--- a/src/main/java/turniplabs/halplibe/util/GameStartEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/GameStartEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 public interface GameStartEntrypoint {
 
     /**

--- a/src/main/java/turniplabs/halplibe/util/GameStartEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/GameStartEntrypoint.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.util;
 
+@Deprecated
 public interface GameStartEntrypoint {
 
     /**

--- a/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-
+@Deprecated
 public interface ItemInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code afterItemInit}.

--- a/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 public interface ItemInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code afterItemInit}.

--- a/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ItemInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 public interface ItemInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code afterItemInit}.

--- a/src/main/java/turniplabs/halplibe/util/ModelEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ModelEntrypoint.java
@@ -8,6 +8,7 @@ import net.minecraft.client.render.block.color.BlockColorDispatcher;
 import net.minecraft.client.render.block.model.BlockModelDispatcher;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
 
+@Deprecated
 @Environment(EnvType.CLIENT)
 public interface ModelEntrypoint {
     /**

--- a/src/main/java/turniplabs/halplibe/util/ModelEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ModelEntrypoint.java
@@ -8,7 +8,7 @@ import net.minecraft.client.render.block.color.BlockColorDispatcher;
 import net.minecraft.client.render.block.model.BlockModelDispatcher;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 @Environment(EnvType.CLIENT)
 public interface ModelEntrypoint {
     /**

--- a/src/main/java/turniplabs/halplibe/util/ModelEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/ModelEntrypoint.java
@@ -8,7 +8,7 @@ import net.minecraft.client.render.block.color.BlockColorDispatcher;
 import net.minecraft.client.render.block.model.BlockModelDispatcher;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 @Environment(EnvType.CLIENT)
 public interface ModelEntrypoint {
     /**

--- a/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 public interface OptionsInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code initOptions}.

--- a/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
@@ -1,7 +1,6 @@
 package turniplabs.halplibe.util;
 
-import net.minecraft.client.option.GameSettings;
-
+@Deprecated
 public interface OptionsInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code initOptions}.

--- a/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/OptionsInitEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 public interface OptionsInitEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code initOptions}.

--- a/src/main/java/turniplabs/halplibe/util/RecipeEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/RecipeEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated
+@Deprecated(since = "6.1.0")
 public interface RecipeEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code recipesReady}.

--- a/src/main/java/turniplabs/halplibe/util/RecipeEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/RecipeEntrypoint.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.util;
 
+@Deprecated
 public interface RecipeEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code recipesReady}.

--- a/src/main/java/turniplabs/halplibe/util/RecipeEntrypoint.java
+++ b/src/main/java/turniplabs/halplibe/util/RecipeEntrypoint.java
@@ -1,6 +1,6 @@
 package turniplabs.halplibe.util;
 
-@Deprecated(since = "6.1.0")
+@Deprecated(since = "6.1.0", forRemoval = true)
 public interface RecipeEntrypoint {
     /**
      * The entrypoint name inside {@code fabric.mod.json} is {@code recipesReady}.

--- a/src/main/java/turniplabs/halplibe/util/collections/CollectionUtils.java
+++ b/src/main/java/turniplabs/halplibe/util/collections/CollectionUtils.java
@@ -1,0 +1,18 @@
+package turniplabs.halplibe.util.collections;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+
+@NullMarked
+public final class CollectionUtils {
+
+    public static <K, V> Map<K, V> mapCollection(final Collection<V> collection, final Map<K, V> outMap, final Function<V, K> mappingFunc) {
+        collection.forEach(o -> outMap.put(mappingFunc.apply(o), o));
+        return outMap;
+    }
+
+    private CollectionUtils() {}
+}

--- a/src/main/java/turniplabs/halplibe/util/dependency/Key.java
+++ b/src/main/java/turniplabs/halplibe/util/dependency/Key.java
@@ -1,0 +1,15 @@
+package turniplabs.halplibe.util.dependency;
+
+import org.jspecify.annotations.NonNull;
+
+public record Key(@NonNull String modId, @NonNull String dependsOn) {
+    private static final String BTA = "bta";
+
+    public static @NonNull Key of(@NonNull String modId) {
+        return new Key(modId, BTA);
+    }
+
+    public static @NonNull Key of(@NonNull String modId, @NonNull String dependsOn) {
+        return new Key(modId, dependsOn);
+    }
+}


### PR DESCRIPTION
## Changes
**Summary:**
- Added a simple event system to replace the existing entrypoint  abuse
- All existing entrypoints have been marked as deprecated for future removal
- Fixed some entrypoint mixins targeting constructors instead of the ``reload`` methods of dispatchers

All existing entrypoints methods have an equivalent event **except** for OptionsInitEntrypoint, which is mostly redundant as of 8.0 and can be safely disregarded.

The ``Emitter``, ``IndirectEmitter`` and ``Event`` interfaces mainly exist for mod developers in case they want to "sandbox" their events and return the listener component only to avoid users calling the event emitters.

## Usage
A ``SingleEvent`` can only be called once. Adding listeners or emitting again after the event has already fired prints a warning with the name of the event included.
```java
SingleEvent<Runnable> someEvent = new SingleEvent<>("SomeSingleEvent");
someEvent.listen(() -> System.out.println("Hello from listener!"));

someEvent.emit(Runnable::run);
```
``BaseEvent`` instances don't have any limit on the number of calls, but otherwise they work the exact same way as single events.
```java
BaseEvent<Runnable> someEvent = new BaseEvent<>("SomeBaseEvent");
someEvent.listen(() -> System.out.println("Hello from listener!"));

someEvent.emit(Runnable::run);
```

The ``CustomEvent`` class can be used to implement more complicated event logic if ever desired (I believe this syntax is the default used by FabricAPI), but HalpLibe does not use this anywhere at the moment.
```java
CustomEvent<Consumer<String>, Consumer<String>> someEvent = new CustomEvent<>(
    listeners -> str -> listeners.forEach(consumer -> consumer.accept(str))
);
someEvent.listen(str -> System.out.println("Hello " + str));

someEvent.getEmitter().accept("World");
```