### PR TITLE
Deprecate old classes & cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,65 @@
 Helper library containing functions for common use cases, while ensuring compatibility between mods.
 
 ## Prerequisites
-- JDK for Java 17 ([Eclipse Temurin](https://adoptium.net/temurin/releases/) recommended)
+- JDK for Java 17 ([Eclipse Temurin](https://adoptium.net/temurin/releases/?version=17) recommended)
 - IntelliJ IDEA
 - Minecraft Development plugin (Optional, but highly recommended)
 
 ## Setup instructions
 Follow the setup instructions on [the example mod](https://github.com/Turnip-Labs/bta-example-mod) GitHub page.
 
-## How to include HalpLibe in a project
-Add this in your `build.gradle`:
-```groovy
-repositories {
-   maven { url = "https://jitpack.io" }
+## Using HalpLibe as a dependency
+
+If you're using the [example mod template](https://github.com/Turnip-Labs/bta-example-mod) HalpLibe should already
+be set up as a dependency so you can safely skip this part.
+
+> [!NOTE]
+> This guide does not include registering a dependency with Fabric Loader, you can read more about
+> that [here](https://docs.fabricmc.net/develop/loader/fabric-mod-json).
+
+### Repository setup
+
+```kotlin
+// [build.gradle.kts]
+
+respositories {
+    // Some BTA modding projects (like HalpLibe) are hosted on the Signalum Maven
+    maven("https://maven.thesignalumproject.net/releases") { name = "SignalumMavenReleases" }
+    maven("https://maven.thesignalumproject.net/nightly") { name = "signalumMavenNightly" }
+    maven("https://maven.thesignalumproject.net/infrastructure") { name = "SignalumMavenInfrastructure" }
 }
+```
+
+### With version catalogs (recommended)
+
+If you are unfamiliar with version catalogs, you can read about them in detail
+[here](https://docs.gradle.org/current/userguide/version_catalogs.html).
+
+```toml
+# [gradle/libs.version.toml]
+
+[versions]
+halplibe = "6.0.2"
+
+[libraries]
+halplibe = { group = "turniplabs", name = "halplibe", version.ref = "halplibe" }
+```
+
+```kotlin
+// [build.gradle.kts]
 
 dependencies {
-    modImplementation "com.github.Turnip-Labs:bta-halplibe:${project.halplibe_version}"
+    implementation(libs.halplibe)
+}
+```
+
+### Without version catalogs
+
+```kotlin
+// [build.gradle.kts]
+
+dependencies {
+    implementation("turniplabs:halplibe:6.0.2")
 }
 ```
 

--- a/src/main/java/turniplabs/halplibe/HalpLibe.java
+++ b/src/main/java/turniplabs/halplibe/HalpLibe.java
@@ -3,7 +3,6 @@ package turniplabs.halplibe;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.minecraft.client.render.texture.stitcher.TextureRegistry;
 import net.minecraft.core.data.registry.Registries;
 import org.jspecify.annotations.NonNull;
@@ -15,10 +14,10 @@ import turniplabs.halplibe.util.toml.Toml;
 import java.io.File;
 import java.io.IOException;
 
-public class HalpLibe implements ModInitializer, PreLaunchEntrypoint {
+public class HalpLibe implements ModInitializer {
+    public static final boolean isClient = FabricLoader.getInstance().getEnvironmentType().equals(EnvType.CLIENT);
     public static final String MOD_ID = HalpLibe.registerMod("halplibe", false);
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
-    public static final boolean isClient = FabricLoader.getInstance().getEnvironmentType().equals(EnvType.CLIENT);
     public static final TomlConfigHandler CONFIG;
 
     static {
@@ -57,22 +56,12 @@ public class HalpLibe implements ModInitializer, PreLaunchEntrypoint {
         }
     }
 
-    @SuppressWarnings("unused")
-    @Deprecated
-    public static String addModId(String modId, String name) {
-        return modId + "." + name;
-    }
-
     @Override
     public void onInitialize() {
         LOGGER.info("HalpLibe initialized.");
     }
 
-    @Override
-    public void onPreLaunch() {
-
-    }
-
+    @SuppressWarnings("unused")
     public static @NonNull String registerMod(@NonNull String modId) {
         return registerMod(modId, true);
     }

--- a/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
@@ -370,6 +370,7 @@ public final class BlockBuilder implements Cloneable {
         T run(Block<?> block);
     }
 
+    @Deprecated(since = "6.1.0", forRemoval = true)
     public static class Registry {
         public static int highestVanilla;
 

--- a/src/main/java/turniplabs/halplibe/helper/CreativeHelper.java
+++ b/src/main/java/turniplabs/halplibe/helper/CreativeHelper.java
@@ -4,6 +4,7 @@ import net.minecraft.core.item.IItemConvertible;
 import net.minecraft.core.item.ItemStack;
 import turniplabs.halplibe.util.CreativeEntry;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public final class CreativeHelper {
     /**
      * @param itemToAdd The itemstack to be added to the creative inventory list

--- a/src/main/java/turniplabs/halplibe/helper/IdSupplierHelper.java
+++ b/src/main/java/turniplabs/halplibe/helper/IdSupplierHelper.java
@@ -5,6 +5,7 @@ import turniplabs.halplibe.util.toml.Toml;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public final class IdSupplierHelper {
     private static final ArrayList<Runnable> registryFunctions = new ArrayList<>();
     private static final ArrayList<Runnable> configuredRegistryFunctions = new ArrayList<>();

--- a/src/main/java/turniplabs/halplibe/helper/ModelHelper.java
+++ b/src/main/java/turniplabs/halplibe/helper/ModelHelper.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.NonNull;
 import java.util.function.Supplier;
 
 @Environment(EnvType.CLIENT)
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class ModelHelper {
 
     public static BlockModelDispatcher blockModelDispatcher;

--- a/src/main/java/turniplabs/halplibe/helper/TextureHelper.java
+++ b/src/main/java/turniplabs/halplibe/helper/TextureHelper.java
@@ -8,9 +8,9 @@ import turniplabs.halplibe.HalpLibe;
 
 import java.util.Optional;
 
-public class TextureHelper {
+@SuppressWarnings("unused")
+public final class TextureHelper {
 
-    @SuppressWarnings("unused")
     public static void initializeAllFiles(String modId, AtlasStitcher atlas, boolean searchSubDirs) {
         Optional<ModContainer> modContainer = FabricLoader.getInstance().getModContainer(modId);
         if (modContainer.isEmpty()) {
@@ -24,4 +24,6 @@ public class TextureHelper {
             HalpLibe.LOGGER.error("Failed to initialize textures for mod '{}' in atlas!", modId, e);
         }
     }
+
+    private TextureHelper() {}
 }

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -53,12 +53,12 @@ public abstract class MinecraftMixin {
         FabricLoader.getInstance().getEntrypoints("afterClientStart", ClientStartEntrypoint.class).forEach(ClientStartEntrypoint::afterClientStart);
         if (HalpLibe.CONFIG.getBoolean("recoveryMode")) {
             PopupScreen popup = new PopupBuilder(this.currentScreen, 246)
-                    .withLabelLiteral(I18n.getInstance().translateKey("halplibe.recoveryMode"))
+                    .withLabelLiteral("/!\\ " + I18n.getInstance().translateKey("halplibe.recoveryMode") + " /!\\")
                     .withMessageBox("message", 128,
                             I18n.getInstance().translateKey("halplibe.recoveryMode.text") + "\n\n"
                                     + I18n.getInstance().translateKey("halplibe.recoveryMode.text2") + "\n"
-                                    + I18n.getInstance().translateKey("halplibe.recoveryMode.action1") + "\n"
-                                    + I18n.getInstance().translateKey("halplibe.recoveryMode.action2") + "\n\n"
+                                    + "- " + I18n.getInstance().translateKey("halplibe.recoveryMode.action1") + "\n"
+                                    + "- " + I18n.getInstance().translateKey("halplibe.recoveryMode.action2") + "\n\n"
                                     + I18n.getInstance().translateKey("halplibe.recoveryMode.text3"), 44)
                     .closeOnClickOut(0)
                     .build();

--- a/src/main/java/turniplabs/halplibe/mixin/recovery/TileEntityRenderDispatcherMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/recovery/TileEntityRenderDispatcherMixin.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 @Environment(EnvType.CLIENT)
 @Mixin(value = TileEntityRenderDispatcher.class,remap = false)
-public class TileEntityRenderDispatcherMixin {
+public abstract class TileEntityRenderDispatcherMixin {
 
     @Shadow
     @Final

--- a/src/main/java/turniplabs/halplibe/mixin/recovery/WorldMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/recovery/WorldMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import turniplabs.halplibe.HalpLibe;
 
 @Mixin(value = World.class,remap = false)
-public class WorldMixin {
+public abstract class WorldMixin {
 
     @WrapWithCondition(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/entity/TileEntity;tick()V"))
     public boolean disableTickingTileEntities(TileEntity instance) {

--- a/src/main/java/turniplabs/halplibe/util/CreativeEntry.java
+++ b/src/main/java/turniplabs/halplibe/util/CreativeEntry.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.NonNull;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class CreativeEntry implements Comparable<CreativeEntry> {
     public static final Map<String, CreativeEntry> priorityEntryMap = new LinkedHashMap<>();
     public static final Map<String, CreativeEntry> childEntryMap = new LinkedHashMap<>();

--- a/src/main/java/turniplabs/halplibe/util/DirectoryManager.java
+++ b/src/main/java/turniplabs/halplibe/util/DirectoryManager.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class DirectoryManager {
     public static final Map<String, HashMap<String, String>> resourceDirectoryMap = new HashMap<>();
     public static final List<String> allKeys = new ArrayList<>();

--- a/src/main/java/turniplabs/halplibe/util/registry/IdSupplier.java
+++ b/src/main/java/turniplabs/halplibe/util/registry/IdSupplier.java
@@ -6,6 +6,7 @@ import turniplabs.halplibe.util.registry.error.RequestOutOfBoundsException;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class IdSupplier {
     String modId;
     RunReserves reserves;

--- a/src/main/java/turniplabs/halplibe/util/registry/Reservation.java
+++ b/src/main/java/turniplabs/halplibe/util/registry/Reservation.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.util.registry;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class Reservation {
     int start, end;
     boolean reserved;

--- a/src/main/java/turniplabs/halplibe/util/registry/RunLengthConfig.java
+++ b/src/main/java/turniplabs/halplibe/util/registry/RunLengthConfig.java
@@ -5,6 +5,7 @@ import turniplabs.halplibe.util.toml.Toml;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class RunLengthConfig {
     public Reservation[] reservations;
 

--- a/src/main/java/turniplabs/halplibe/util/registry/RunReserves.java
+++ b/src/main/java/turniplabs/halplibe/util/registry/RunReserves.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class RunReserves {
     ArrayList<Reservation> reservations = new ArrayList<>();
 

--- a/src/main/java/turniplabs/halplibe/util/registry/error/RequestCutShortException.java
+++ b/src/main/java/turniplabs/halplibe/util/registry/error/RequestCutShortException.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.util.registry.error;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class RequestCutShortException extends RuntimeException {
     public RequestCutShortException(String message) {
         super(message);

--- a/src/main/java/turniplabs/halplibe/util/registry/error/RequestOutOfBoundsException.java
+++ b/src/main/java/turniplabs/halplibe/util/registry/error/RequestOutOfBoundsException.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.util.registry.error;
 
+@Deprecated(since = "6.1.0", forRemoval = true)
 public class RequestOutOfBoundsException extends RuntimeException {
     public RequestOutOfBoundsException(String message) {
         super(message);

--- a/src/main/resources/assets/halplibe/lang/en_US/en_US.lang
+++ b/src/main/resources/assets/halplibe/lang/en_US/en_US.lang
@@ -1,6 +1,6 @@
-halplibe.recoveryMode=/!\\ Recovery Mode /!\\
+halplibe.recoveryMode=Recovery Mode
 halplibe.recoveryMode.text=Recovery mode disables certain parts of the game to prevent crash loops.
 halplibe.recoveryMode.text2=The following actions have been taken:
-halplibe.recoveryMode.action1=- Tile entity ticking disabled.
-halplibe.recoveryMode.action2=- Tile entity rendering disabled.
+halplibe.recoveryMode.action1=Tile entity ticking disabled.
+halplibe.recoveryMode.action2=Tile entity rendering disabled.
 halplibe.recoveryMode.text3=Click anywhere outside this popup to close.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,9 +20,6 @@
   "entrypoints": {
     "main": [
       "turniplabs.halplibe.HalpLibe"
-    ],
-    "preLaunch": [
-      "turniplabs.halplibe.HalpLibe"
     ]
   },
   "mixins": [


### PR DESCRIPTION
This PR ~~removes~~ deprecates the following classes:
- ``CreativeHelper``
- ``IdSupplierHelper``
- ``ModelHelper``
- ``IdSupplier``
- ``Reservation``
- ``RunLengthConfig``
- ``RunReserves``
- ``CreativeEntry``
- ``DirectoryManager``
- ``BlockBuilder.Registry``

Other tweaks:
- Removed unused preLaunch entrypoint
- Removed unused addModId method
- Made some mixins abstract
- Moved recovery mode formatting out of lang files
- Made TextureHelper final
- Updated README