### PR TITLE
Build script and dependency changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,20 @@ Helper library containing functions for common use cases, while ensuring compati
 Follow the setup instructions on [the example mod](https://github.com/Turnip-Labs/bta-example-mod) GitHub page.
 
 ## How to include HalpLibe in a project
-Add this in your `build.gradle`:
-```groovy
-repositories {
-   maven { url = "https://jitpack.io" }
-}
 
+Update the ``/gradle/libs.versions.toml`` config file:
+```toml
+[versions]
+halplibe = "6.0.2"
+
+[libraries]
+halplibe = { group = "turniplabs", name = "halplibe", version.ref = "halplibe" }
+```
+
+Update the ``build.gradle.kts`` script:
+```kotlin
 dependencies {
-    modImplementation "com.github.Turnip-Labs:bta-halplibe:${project.halplibe_version}"
+    implementation(libs.halplibe)
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,15 +183,9 @@ fun resolveLwjglNatives(): String { // Sourced from https://www.lwjgl.org/
         System.getProperty("os.arch")!!
     ).let { (name, arch) ->
         when {
-            "FreeBSD" == name ->
-                "natives-freebsd"
             arrayOf("Linux", "SunOS", "Unit").any { name.startsWith(it) } ->
                 if (arrayOf("arm", "aarch64").any { arch.startsWith(it) })
                     "natives-linux${if (arch.contains("64") || arch.startsWith("armv8")) "-arm64" else "-arm32"}"
-                else if (arch.startsWith("ppc"))
-                    "natives-linux-ppc64le"
-                else if (arch.startsWith("riscv"))
-                    "natives-linux-riscv64"
                 else
                     "natives-linux"
             arrayOf("Mac OS X", "Darwin").any { name.startsWith(it) } ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,8 @@ dependencies {
     implementation(libs.legacyLwjgl)
 
     implementation(libs.slf4jApi)
-    implementation(libs.guava)
+    compileOnly(libs.jspecify)
+    compileOnly(libs.errorprone)
     implementation(libs.log4j.slf4j2.impl)
     implementation(libs.log4j.core)
     implementation(libs.log4j.api)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,7 @@ plugins {
     `maven-publish`
 }
 
-val osName: String = System.getProperty("os.name").lowercase().replace(" ", "")
-val lwjglNativeList = arrayOf("macos", "windows", "linux")
-val lwjglNativesName = "natives-${lwjglNativeList.find { it in osName }}"
+val lwjglNatives = resolveLwjglNatives()
 
 val modVersion: Provider<String> = providers.gradleProperty("mod_version")
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
@@ -57,11 +55,11 @@ dependencies {
     localRuntime(libs.modMenu) // Optional, can be removed
     val lwjglVer = libs.versions.lwjgl.get()
     localRuntime(platform("org.lwjgl:lwjgl-bom:${lwjglVer}"))
-    localRuntime("org.lwjgl:lwjgl::$lwjglNativesName")
-    localRuntime("org.lwjgl:lwjgl-glfw::$lwjglNativesName")
-    localRuntime("org.lwjgl:lwjgl-openal::$lwjglNativesName")
-    localRuntime("org.lwjgl:lwjgl-opengl::$lwjglNativesName")
-    localRuntime("org.lwjgl:lwjgl-stb::$lwjglNativesName")
+    localRuntime("org.lwjgl:lwjgl::$lwjglNatives")
+    localRuntime("org.lwjgl:lwjgl-glfw::$lwjglNatives")
+    localRuntime("org.lwjgl:lwjgl-openal::$lwjglNatives")
+    localRuntime("org.lwjgl:lwjgl-opengl::$lwjglNatives")
+    localRuntime("org.lwjgl:lwjgl-stb::$lwjglNatives")
 }
 
 java {
@@ -119,6 +117,10 @@ tasks {
             "java" to libs.versions.java.get(),
             "modmenu" to libs.versions.modMenu.get()
         )
+        // This is needed for gradle to recognize changes
+        // made to expanded files
+        inputs.properties(resourceMap)
+
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
         with(copySpec {
             from("src/main/resources/") {
@@ -172,5 +174,35 @@ if (modrinthToken.isPresent) {
         gameVersions.add("b1.7.3")
         loaders.add("bta-babric")
         changelog = Files.readString(rootProject.projectDir.toPath().resolve("CHANGELOG.md"))
+    }
+}
+
+fun resolveLwjglNatives(): String { // Sourced from https://www.lwjgl.org/
+    return Pair(
+        System.getProperty("os.name")!!,
+        System.getProperty("os.arch")!!
+    ).let { (name, arch) ->
+        when {
+            "FreeBSD" == name ->
+                "natives-freebsd"
+            arrayOf("Linux", "SunOS", "Unit").any { name.startsWith(it) } ->
+                if (arrayOf("arm", "aarch64").any { arch.startsWith(it) })
+                    "natives-linux${if (arch.contains("64") || arch.startsWith("armv8")) "-arm64" else "-arm32"}"
+                else if (arch.startsWith("ppc"))
+                    "natives-linux-ppc64le"
+                else if (arch.startsWith("riscv"))
+                    "natives-linux-riscv64"
+                else
+                    "natives-linux"
+            arrayOf("Mac OS X", "Darwin").any { name.startsWith(it) } ->
+                "natives-macos${if (arch.startsWith("aarch64")) "-arm64" else ""}"
+            arrayOf("Windows").any { name.startsWith(it) } ->
+                if (arch.contains("64"))
+                    "natives-windows${if (arch.startsWith("aarch64")) "-arm64" else ""}"
+                else
+                    "natives-windows-x86"
+            else ->
+                throw Error("Unrecognized or unsupported platform. Please set \"lwjglNatives\" manually")
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,6 @@ repositories {
     maven("https://maven.thesignalumproject.net/infrastructure") { name = "SignalumMavenInfrastructure" }
     maven("https://maven.thesignalumproject.net/nightly") { name = "signalumMavenNightly" }
     maven("https://maven.thesignalumproject.net/releases") { name = "SignalumMavenReleases" }
-    ivy("https://github.com/Better-than-Adventure") {
-        patternLayout { artifact("[organisation]/releases/download/[revision]/[module]-bta-[revision].jar") }
-        metadataSources { artifact() }
-    }
     ivy("https://piston-data.mojang.com") {
         patternLayout { artifact("v1/[organisation]/[revision]/[module].jar") }
         metadataSources { artifact() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,16 @@
-import com.smushytaco.lwjgl_gradle.Preset
 import java.nio.file.Files
 
 plugins {
     alias(libs.plugins.loom)
     alias(libs.plugins.minotaur)
-    alias(libs.plugins.lwjgl)
     java
     `maven-publish`
 }
+
+val osName: String = System.getProperty("os.name").lowercase().replace(" ", "")
+val lwjglNativeList = arrayOf("macos", "windows", "linux")
+val lwjglNativesName = "natives-${lwjglNativeList.find { it in osName }}"
+
 val modVersion: Provider<String> = providers.gradleProperty("mod_version")
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
 val modName: Provider<String> = providers.gradleProperty("mod_name")
@@ -30,39 +33,41 @@ repositories {
         patternLayout { artifact("[organisation]/releases/download/[revision]/[module]-bta-[revision].jar") }
         metadataSources { artifact() }
     }
-    ivy("https://downloads.betterthanadventure.net/bta-client/${libs.versions.btaChannel.get()}/") {
-        patternLayout { artifact("/v[revision]/client.jar") }
-        metadataSources { artifact() }
-    }
-    ivy("https://downloads.betterthanadventure.net/bta-server/${libs.versions.btaChannel.get()}/") {
-        patternLayout { artifact("/v[revision]/server.jar") }
-        metadataSources { artifact() }
-    }
     ivy("https://piston-data.mojang.com") {
         patternLayout { artifact("v1/[organisation]/[revision]/[module].jar") }
         metadataSources { artifact() }
     }
 }
-lwjgl {
-    version = libs.versions.lwjgl
-    implementation(Preset.MINIMAL_OPENGL)
-}
+
 dependencies {
     minecraft("::${libs.versions.bta.get()}")
 
-    runtimeOnly(libs.clientJar)
+    // Required at compilation & runtime
+    // included in builds as a runtime dependency
     implementation(libs.loader)
-    implementation(libs.modMenu)
-    implementation(libs.legacyLwjgl)
 
-    implementation(libs.slf4jApi)
+    // Only required at compilation
+    // provides documentation, can be removed if that isn't needed
+    compileOnly(libs.bundles.btaLwjgl)
+    compileOnly(libs.joml)
+    compileOnly(libs.joml.primitives)
+    compileOnly(libs.slf4jApi)
+
     compileOnly(libs.jspecify)
     compileOnly(libs.errorprone)
-    implementation(libs.log4j.slf4j2.impl)
-    implementation(libs.log4j.core)
-    implementation(libs.log4j.api)
-    implementation(libs.log4j.api12)
+
+    // Only required for development/launch at runtime, won't be part of any builds
+    runtimeClasspath(libs.clientJar)
+    localRuntime(libs.modMenu) // Optional, can be removed
+    val lwjglVer = libs.versions.lwjgl.get()
+    localRuntime(platform("org.lwjgl:lwjgl-bom:${lwjglVer}"))
+    localRuntime("org.lwjgl:lwjgl::$lwjglNativesName")
+    localRuntime("org.lwjgl:lwjgl-glfw::$lwjglNativesName")
+    localRuntime("org.lwjgl:lwjgl-openal::$lwjglNativesName")
+    localRuntime("org.lwjgl:lwjgl-opengl::$lwjglNativesName")
+    localRuntime("org.lwjgl:lwjgl-stb::$lwjglNativesName")
 }
+
 java {
     toolchain {
         languageVersion = javaVersion.map { JavaLanguageVersion.of(it) }
@@ -128,8 +133,14 @@ tasks {
         })
     }
 }
-// Removes LWJGL2 dependencies
-configurations.configureEach { exclude(group = "org.lwjgl.lwjgl") }
+// Removes all outdated manifest.json dependencies
+configurations.configureEach {
+    exclude(group = "org.lwjgl.lwjgl")
+    exclude(group = "net.java.jutils")
+    exclude(group = "net.java.jinput")
+    exclude(group = "net.sf.jopt-simple")
+    exclude(group = "net.minecraft", module = "launchwrapper")
+}
 
 publishing {
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,10 +61,6 @@ dependencies {
     implementation(libs.log4j.core)
     implementation(libs.log4j.api)
     implementation(libs.log4j.api12)
-    implementation(libs.gson)
-
-    implementation(libs.commonsLang3)
-    include(libs.commonsLang3)
 }
 java {
     toolchain {
@@ -121,9 +117,14 @@ tasks {
             "java" to libs.versions.java.get(),
             "modmenu" to libs.versions.modMenu.get()
         )
-        inputs.properties(resourceMap)
-        filesMatching("fabric.mod.json") { expand(resourceMap) }
-        filesMatching("**/*.mixins.json") { expand(resourceMap.filterKeys { it == "java" }) }
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        with(copySpec {
+            from("src/main/resources/") {
+                include("fabric.mod.json")
+                include("*.mixins.json")
+                expand(resourceMap)
+            }
+        })
     }
 }
 // Removes LWJGL2 dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,6 @@ slf4jApi = "2.0.17"
 guava = "33.5.0-jre"
 # Check this on https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-api/
 log4j = "2.20.0"
-# Check this on https://central.sonatype.com/artifact/com.google.code.gson/gson/
-gson = "2.13.2"
-# Check this on https://central.sonatype.com/artifact/org.apache.commons/commons-lang3/
-commonsLang3 = "3.20.0"
 # This should match the version used by the current BTA release.
 lwjgl = "3.3.3"
 ##########################################################################
@@ -51,8 +47,6 @@ log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-i
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLang3" }
 # https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
 clientJar = { group = "objects", name = "client", version = "43db9b498cb67058d2e12d394e6507722e71bb45" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ btaChannel = "prerelease"
 # Check this on https://maven.thesignalumproject.net/#/infrastructure/net/fabricmc/fabric-loader/
 loader = "0.18.4-bta.11"
 # Check this on https://github.com/Turnip-Labs/ModMenu/releases/latest/
-modMenu = "5.0.0"
+modMenu = "5.0.1"
 # Check this on https://maven.thesignalumproject.net/#/infrastructure/com/github/Better-than-Adventure/legacy-lwjgl3/
 legacyLwjgl = "1.0.6"
 ##########################################################################

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,8 @@ legacyLwjgl = "1.0.6"
 # Check this on https://central.sonatype.com/artifact/org.slf4j/slf4j-api/
 slf4jApi = "2.0.17"
 # Check this on https://central.sonatype.com/artifact/com.google.guava/guava/
-guava = "33.5.0-jre"
+jspecify = "1.0.0"
+errorprone = "2.49.0"
 # Check this on https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-api/
 log4j = "2.20.0"
 # This should match the version used by the current BTA release.
@@ -42,7 +43,8 @@ loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "loader
 modMenu = { group = "turniplabs", name = "modmenu-bta", version.ref = "modMenu" }
 legacyLwjgl = { group = "com.github.Better-than-Adventure", name = "legacy-lwjgl3", version.ref = "legacyLwjgl" }
 slf4jApi = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4jApi" }
-guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
+jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
+errorprone = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "errorprone" }
 log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "log4j" }
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,6 @@
 # Plugins
 # Check this on https://github.com/FabricMC/fabric-loom/releases/latest/
 loom = "1.15-SNAPSHOT"
-# Check this on https://plugins.gradle.org/plugin/com.smushytaco.lwjgl3/
-lwjglPlugin = "1.0.2"
 # Check this on https://plugins.gradle.org/plugin/com.modrinth.minotaur/
 minotaur = "2.9.0"
 ##########################################################################
@@ -32,10 +30,10 @@ slf4jApi = "2.0.17"
 # Check this on https://central.sonatype.com/artifact/com.google.guava/guava/
 jspecify = "1.0.0"
 errorprone = "2.49.0"
-# Check this on https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-api/
-log4j = "2.20.0"
 # This should match the version used by the current BTA release.
 lwjgl = "3.3.3"
+joml = "1.10.8"
+jomlPrimitivess = "1.10.0"
 ##########################################################################
 
 [libraries]
@@ -45,14 +43,20 @@ legacyLwjgl = { group = "com.github.Better-than-Adventure", name = "legacy-lwjgl
 slf4jApi = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4jApi" }
 jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 errorprone = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "errorprone" }
-log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "log4j" }
-log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
-log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
-log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
 # https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
 clientJar = { group = "objects", name = "client", version = "43db9b498cb67058d2e12d394e6507722e71bb45" }
+
+joml = { group = "org.joml", name = "joml", version.ref = "joml" }
+joml-primitives = { group = "org.joml", name = "joml-primitives", version.ref = "jomlPrimitivess" }
+lwjgl = { group = "org.lwjgl", name = "lwjgl", version.ref = "lwjgl"}
+lwjgl-glfw = { group = "org.lwjgl", name = "lwjgl-glfw", version.ref = "lwjgl"}
+lwjgl-openal = { group = "org.lwjgl", name = "lwjgl-openal", version.ref = "lwjgl"}
+lwjgl-opengl = { group = "org.lwjgl", name = "lwjgl-opengl", version.ref = "lwjgl"}
+lwjgl-stb = { group = "org.lwjgl", name = "lwjgl-stb", version.ref = "lwjgl"}
+
+[bundles]
+btaLwjgl = [ "lwjgl", "lwjgl-glfw", "lwjgl-openal", "lwjgl-opengl", "lwjgl-stb", "legacyLwjgl" ]
 
 [plugins]
 loom = { id = "net.fabricmc.fabric-loom", version.ref = "loom" }
 minotaur = { id = "com.modrinth.minotaur", version.ref = "minotaur" }
-lwjgl = { id = "com.smushytaco.lwjgl3", version.ref = "lwjglPlugin" }

--- a/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
@@ -8,21 +8,25 @@ import net.minecraft.core.data.tag.Tag;
 import net.minecraft.core.item.IItemConvertible;
 import net.minecraft.core.item.block.ItemBlock;
 import net.minecraft.core.sound.BlockSound;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryPlacement;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryRegistry;
 import turniplabs.halplibe.mixin.accessors.BlocksAccessor;
+import turniplabs.halplibe.util.ArrayUtils;
 import turniplabs.halplibe.util.registry.IdSupplier;
 import turniplabs.halplibe.util.registry.RunLengthConfig;
 import turniplabs.halplibe.util.registry.RunReserves;
 import turniplabs.halplibe.util.toml.Toml;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+@NullMarked
+@SuppressWarnings("unused")
 public final class BlockBuilder implements Cloneable {
-    private final @NonNull String modId;
+    private final String modId;
 
     private @Nullable Float hardness = null;
     private @Nullable Float resistance = null;
@@ -35,7 +39,7 @@ public final class BlockBuilder implements Cloneable {
     private int @Nullable [] flammability = null;
     private @Nullable BlockSound blockSound = null;
     private @Nullable BlockLambda<ItemBlock<?>> customBlockItem = null;
-    private @Nullable Tag<Block<?>>[] tags = null;
+    private Tag<Block<?>>[] tags = ArrayUtils.newArray(Tag.class, 0);
     private @Nullable Supplier<TileEntity> entitySupplier = null;
     private boolean disableStats = false;
     private @Nullable Float particleGravity = null;
@@ -43,7 +47,7 @@ public final class BlockBuilder implements Cloneable {
     private @Nullable Supplier<IItemConvertible> statParent = null;
     private @Nullable CreativeInventoryPlacement creativeInventoryPlacement = null;
 
-    public BlockBuilder(@NonNull String modId) {
+    public BlockBuilder(String modId) {
         this.modId = modId;
     }
 
@@ -64,7 +68,7 @@ public final class BlockBuilder implements Cloneable {
      * @return @return Copy of {@link ItemBuilder}
      */
     @SuppressWarnings("unused")
-    public @NonNull BlockBuilder setTileEntity(@Nullable Supplier<TileEntity> tileEntitySupplier) {
+    public BlockBuilder setTileEntity(@Nullable Supplier<TileEntity> tileEntitySupplier) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.entitySupplier = tileEntitySupplier;
         return blockBuilder;
@@ -74,7 +78,7 @@ public final class BlockBuilder implements Cloneable {
      * Sets how long it takes to break the block.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setHardness(float hardness) {
+    public BlockBuilder setHardness(float hardness) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.hardness = hardness;
         return blockBuilder;
@@ -84,7 +88,7 @@ public final class BlockBuilder implements Cloneable {
      * Sets the block's resistance against explosions.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setResistance(float resistance) {
+    public BlockBuilder setResistance(float resistance) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.resistance = resistance;
         return blockBuilder;
@@ -96,7 +100,7 @@ public final class BlockBuilder implements Cloneable {
      * @param luminance ranges from 0 to 15
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setLuminance(int luminance) {
+    public BlockBuilder setLuminance(int luminance) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.luminance = luminance;
         return blockBuilder;
@@ -111,7 +115,7 @@ public final class BlockBuilder implements Cloneable {
      * @param lightOpacity ranges from 0 to 15
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setLightOpacity(int lightOpacity) {
+    public BlockBuilder setLightOpacity(int lightOpacity) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.lightOpacity = lightOpacity;
         return blockBuilder;
@@ -121,7 +125,7 @@ public final class BlockBuilder implements Cloneable {
      * Sets the block's slipperiness, 0.6 is default, 0.98 is ice.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setSlipperiness(float slipperiness) {
+    public BlockBuilder setSlipperiness(float slipperiness) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.slipperiness = slipperiness;
         return blockBuilder;
@@ -136,7 +140,7 @@ public final class BlockBuilder implements Cloneable {
      *                          to ash and disappear
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setFlammability(int chanceToCatchFire, int chanceToDegrade) {
+    public BlockBuilder setFlammability(int chanceToCatchFire, int chanceToDegrade) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.flammability = new int[]{chanceToCatchFire, chanceToDegrade};
         return blockBuilder;
@@ -146,7 +150,7 @@ public final class BlockBuilder implements Cloneable {
      * Makes a block unable to be broken.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setUnbreakable() {
+    public BlockBuilder setUnbreakable() {
         BlockBuilder blockBuilder = clone();
         blockBuilder.hardness = -1.0f;
         return blockBuilder;
@@ -156,7 +160,7 @@ public final class BlockBuilder implements Cloneable {
      * Makes fire burn indefinitely on top of the block.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setInfiniburn() {
+    public BlockBuilder setInfiniburn() {
         BlockBuilder blockBuilder = clone();
         blockBuilder.infiniburn = true;
         return blockBuilder;
@@ -168,7 +172,7 @@ public final class BlockBuilder implements Cloneable {
      * blocks that allow light to pass through them.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setUseInternalLight() {
+    public BlockBuilder setUseInternalLight() {
         BlockBuilder blockBuilder = clone();
         blockBuilder.useInternalLight = true;
         return blockBuilder;
@@ -178,7 +182,7 @@ public final class BlockBuilder implements Cloneable {
      * Makes the block receive a tick update when the game loads the chunk the block is in.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setTicking(boolean ticking) {
+    public BlockBuilder setTicking(boolean ticking) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.ticking = ticking;
         return blockBuilder;
@@ -194,7 +198,7 @@ public final class BlockBuilder implements Cloneable {
      * }</pre>
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setBlockSound(BlockSound blockSound) {
+    public BlockBuilder setBlockSound(@Nullable BlockSound blockSound) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.blockSound = blockSound;
         return blockBuilder;
@@ -210,7 +214,7 @@ public final class BlockBuilder implements Cloneable {
      * }</pre>
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setBlockItem(BlockLambda<ItemBlock<?>> customBlockItem) {
+    public BlockBuilder setBlockItem(@Nullable BlockLambda<ItemBlock<?>> customBlockItem) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.customBlockItem = customBlockItem;
         return blockBuilder;
@@ -221,9 +225,9 @@ public final class BlockBuilder implements Cloneable {
      */
     @SafeVarargs
     @SuppressWarnings({"unused"})
-    public final @NonNull BlockBuilder setTags(Tag<Block<?>>... tags) {
+    public final BlockBuilder setTags(Tag<Block<?>>... tags) {
         BlockBuilder blockBuilder = clone();
-        blockBuilder.tags = tags;
+        blockBuilder.tags = Arrays.copyOf(tags, tags.length);
         return blockBuilder;
     }
 
@@ -232,9 +236,9 @@ public final class BlockBuilder implements Cloneable {
      */
     @SafeVarargs
     @SuppressWarnings({"unused"})
-    public final @NonNull BlockBuilder addTags(Tag<Block<?>>... tags) {
+    public final BlockBuilder addTags(Tag<Block<?>>... tags) {
         BlockBuilder blockBuilder = clone();
-        blockBuilder.tags = tags;
+        blockBuilder.tags = ArrayUtils.addAll(this.tags, tags);
         return blockBuilder;
     }
 
@@ -242,7 +246,7 @@ public final class BlockBuilder implements Cloneable {
      * Disables stats for a block.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setDisableStats() {
+    public BlockBuilder setDisableStats() {
         BlockBuilder blockBuilder = clone();
         blockBuilder.disableStats = true;
         return blockBuilder;
@@ -252,7 +256,7 @@ public final class BlockBuilder implements Cloneable {
      * Sets the gravity applied to block particles.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setParticleGravity(float particleGravity) {
+    public BlockBuilder setParticleGravity(float particleGravity) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.particleGravity = particleGravity;
         return blockBuilder;
@@ -262,7 +266,7 @@ public final class BlockBuilder implements Cloneable {
      * Overrides the block color used for the map.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setOverrideColor(MaterialColor overrideColor) {
+    public BlockBuilder setOverrideColor(@Nullable MaterialColor overrideColor) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.overrideColor = overrideColor;
         return blockBuilder;
@@ -272,7 +276,7 @@ public final class BlockBuilder implements Cloneable {
      * Sets the parent item used for statistics.
      */
     @SuppressWarnings({"unused"})
-    public @NonNull BlockBuilder setStatParent(Supplier<IItemConvertible> statParent) {
+    public BlockBuilder setStatParent(@Nullable Supplier<IItemConvertible> statParent) {
         BlockBuilder blockBuilder = clone();
         blockBuilder.statParent = statParent;
         return blockBuilder;
@@ -295,7 +299,7 @@ public final class BlockBuilder implements Cloneable {
      * @param blockLogicSupplier {@link BlockLogic} that will be assigned to the Block on creation
      * @return Returns the {@link Block} after registration and configuration
      */
-    public <T extends BlockLogic> @NonNull Block<T> build(String translationKey, String name, int numericId, BlockLogicSupplier<T> blockLogicSupplier) {
+    public <T extends BlockLogic> Block<T> build(String translationKey, String name, int numericId, BlockLogicSupplier<T> blockLogicSupplier) {
         Block<T> block = Blocks.register(
                 String.format("%s.%s", modId, translationKey),
                 String.format("%s:block/%s", modId, name),
@@ -315,7 +319,7 @@ public final class BlockBuilder implements Cloneable {
         if (overrideColor != null) block.withOverrideColor(overrideColor);
         if (blockSound != null) block.withSound(blockSound);
         if (entitySupplier != null) block.withEntity(entitySupplier);
-        if (tags != null) block.withTags(tags);
+        block.withTags(tags);
         if (customBlockItem != null) block.setBlockItem(() -> customBlockItem.run(block));
         if (flammability != null) BlockLogicFire.setFlammable(block, flammability[0], flammability[1]);
         if (disableStats) block.withDisabledStats();
@@ -339,7 +343,7 @@ public final class BlockBuilder implements Cloneable {
      * automatically converts to log.apple for translation key.
      */
     @SuppressWarnings({"unused"})
-    public <T extends BlockLogic> @NonNull Block<T> build(String identifier, int numericId, BlockLogicSupplier<T> logicSupplier) {
+    public <T extends BlockLogic> Block<T> build(String identifier, int numericId, BlockLogicSupplier<T> logicSupplier) {
         String translationKey;
         String name;
         if (identifier.contains(".")) {

--- a/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
@@ -8,7 +8,6 @@ import net.minecraft.core.data.tag.Tag;
 import net.minecraft.core.item.IItemConvertible;
 import net.minecraft.core.item.block.ItemBlock;
 import net.minecraft.core.sound.BlockSound;
-import org.apache.commons.lang3.ArrayUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryPlacement;
@@ -235,7 +234,7 @@ public final class BlockBuilder implements Cloneable {
     @SuppressWarnings({"unused"})
     public final @NonNull BlockBuilder addTags(Tag<Block<?>>... tags) {
         BlockBuilder blockBuilder = clone();
-        blockBuilder.tags = ArrayUtils.addAll(this.tags, tags);
+        blockBuilder.tags = tags;
         return blockBuilder;
     }
 

--- a/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
@@ -2,8 +2,6 @@ package turniplabs.halplibe.helper;
 
 import net.minecraft.core.data.tag.Tag;
 import net.minecraft.core.item.Item;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryPlacement;
@@ -119,7 +117,7 @@ public final class ItemBuilder implements Cloneable {
     @SuppressWarnings({"unused"})
     public final @NonNull ItemBuilder addTags(Tag<Item>... tags) {
         ItemBuilder itemBuilder = this.clone();
-        itemBuilder.tags = ArrayUtils.addAll(this.tags, tags);
+        itemBuilder.tags = tags;
         return itemBuilder;
     }
 
@@ -162,7 +160,7 @@ public final class ItemBuilder implements Cloneable {
         newTokens.addAll(tokens.subList(1, tokens.size()));
 
         Item.nameToIdMap.remove(item.getKey(), item.id);
-        ((ItemAccessor) item).setKey(StringUtils.join(newTokens, "."));
+        ((ItemAccessor) item).setKey(String.join(".", newTokens));
         Item.nameToIdMap.put(item.getKey(), item.id);
 
         return item;

--- a/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
@@ -50,7 +50,7 @@ public final class ItemBuilder implements Cloneable {
     @SuppressWarnings({"unused"})
     public ItemBuilder setKey(String key) {
         ItemBuilder builder = this.clone();
-        builder.overrideKey = key;
+        builder.overrideKey = "item." + key;
         return builder;
     }
 
@@ -154,7 +154,7 @@ public final class ItemBuilder implements Cloneable {
         newTokens.addAll(tokens.subList(1, tokens.size()));
 
         Item.nameToIdMap.remove(item.getKey(), item.id);
-        ((ItemAccessor) item).setKey(String.join(".", newTokens));
+        ((ItemAccessor) item).setKey("item." + String.join(".", newTokens));
         Item.nameToIdMap.put(item.getKey(), item.id);
 
         return item;

--- a/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
@@ -47,10 +47,11 @@ public final class ItemBuilder implements Cloneable {
      * @param key Override translation key for the {@link Item}
      * @return Copy of {@link ItemBuilder}
      */
+    @Deprecated
     @SuppressWarnings({"unused"})
     public ItemBuilder setKey(String key) {
         ItemBuilder builder = this.clone();
-        builder.overrideKey = "item." + key;
+        builder.overrideKey = key;
         return builder;
     }
 

--- a/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
@@ -2,33 +2,32 @@ package turniplabs.halplibe.helper;
 
 import net.minecraft.core.data.tag.Tag;
 import net.minecraft.core.item.Item;
-import org.jetbrains.annotations.Nullable;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryPlacement;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryRegistry;
 import turniplabs.halplibe.mixin.accessors.ItemAccessor;
 import turniplabs.halplibe.mixin.accessors.ItemDamageAccessor;
+import turniplabs.halplibe.util.ArrayUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
+@NullMarked
+@SuppressWarnings("unused")
 public final class ItemBuilder implements Cloneable {
-    private final @NonNull String modId;
-    @Nullable
-    private String overrideKey = null;
-    @Nullable
-    private Tag<Item>[] tags = null;
-    private Integer stackSize = null;
-    private Integer maxDamage = null;
-    @Nullable
-    private Supplier<Item> containerItemSupplier = null;
-    private @NonNull CreativeInventoryPlacement creativeInventoryPlacement = null;
+    private final String modId;
 
+    private @Nullable String overrideKey = null;
+    public Tag<Item>[] tags = ArrayUtils.newArray(Tag.class, 0);
+    private @Nullable Integer stackSize = null;
+    private @Nullable Integer maxDamage = null;
+    private @Nullable Supplier<Item> containerItemSupplier = null;
+    private @Nullable CreativeInventoryPlacement creativeInventoryPlacement = null;
 
-    public ItemBuilder(@NonNull String modId) {
+    public ItemBuilder(String modId) {
         this.modId = modId;
     }
 
@@ -49,7 +48,7 @@ public final class ItemBuilder implements Cloneable {
      * @return Copy of {@link ItemBuilder}
      */
     @SuppressWarnings({"unused"})
-    public @NonNull ItemBuilder setKey(String key) {
+    public ItemBuilder setKey(String key) {
         ItemBuilder builder = this.clone();
         builder.overrideKey = key;
         return builder;
@@ -62,7 +61,7 @@ public final class ItemBuilder implements Cloneable {
      * @return Copy of {@link ItemBuilder}
      */
     @SuppressWarnings({"unused"})
-    public @NonNull ItemBuilder setStackSize(int stackSize) {
+    public ItemBuilder setStackSize(int stackSize) {
         ItemBuilder builder = this.clone();
         builder.stackSize = stackSize;
         return builder;
@@ -76,7 +75,7 @@ public final class ItemBuilder implements Cloneable {
      * @return Copy of {@link ItemBuilder}
      */
     @SuppressWarnings({"unused"})
-    public @NonNull ItemBuilder setMaxDamage(int maxDamage) {
+    public ItemBuilder setMaxDamage(int maxDamage) {
         ItemBuilder builder = this.clone();
         builder.maxDamage = maxDamage;
         return builder;
@@ -89,7 +88,7 @@ public final class ItemBuilder implements Cloneable {
      * @return Copy of {@link ItemBuilder}
      */
     @SuppressWarnings({"unused"})
-    public @NonNull ItemBuilder setContainerItem(Supplier<Item> itemSupplier) {
+    public ItemBuilder setContainerItem(@Nullable Supplier<Item> itemSupplier) {
         ItemBuilder builder = this.clone();
         builder.containerItemSupplier = itemSupplier;
         return builder;
@@ -102,9 +101,9 @@ public final class ItemBuilder implements Cloneable {
      */
     @SafeVarargs
     @SuppressWarnings({"unused"})
-    public final @NonNull ItemBuilder setTags(Tag<Item>... tags) {
+    public final ItemBuilder setTags(Tag<Item>... tags) {
         ItemBuilder itemBuilder = this.clone();
-        itemBuilder.tags = tags;
+        itemBuilder.tags = Arrays.copyOf(tags, tags.length);
         return itemBuilder;
     }
 
@@ -115,16 +114,16 @@ public final class ItemBuilder implements Cloneable {
      */
     @SafeVarargs
     @SuppressWarnings({"unused"})
-    public final @NonNull ItemBuilder addTags(Tag<Item>... tags) {
+    public final ItemBuilder addTags(Tag<Item>... tags) {
         ItemBuilder itemBuilder = this.clone();
-        itemBuilder.tags = tags;
+        itemBuilder.tags = ArrayUtils.addAll(this.tags, tags);
         return itemBuilder;
     }
 
     /**
      * Adds item to the creative inventory based on the placement construct
      */
-    public ItemBuilder setCreativeInventoryPlacement(@NonNull CreativeInventoryPlacement creativeInventoryPlacement) {
+    public ItemBuilder setCreativeInventoryPlacement(@Nullable CreativeInventoryPlacement creativeInventoryPlacement) {
         ItemBuilder itemBuilder = this.clone();
         itemBuilder.creativeInventoryPlacement = creativeInventoryPlacement;
         return itemBuilder;
@@ -138,15 +137,10 @@ public final class ItemBuilder implements Cloneable {
      */
     @SuppressWarnings("unused")
     public <T extends Item> T build(T item) {
-        List<String> tokens;
+        final String theKey = overrideKey == null ? item.getKey() : overrideKey;
+        List<String> tokens = Arrays.asList(theKey.split("\\."));
 
-        if (overrideKey != null){
-            tokens = Arrays.stream(overrideKey.split("\\.")).collect(Collectors.toList());
-        } else {
-            tokens = Arrays.stream(item.getKey().split("\\.")).collect(Collectors.toList());
-        }
-
-        if (tags != null) item.withTags(tags);
+        item.withTags(tags);
         if (stackSize != null) item.setMaxStackSize(stackSize);
         if (containerItemSupplier != null) item.setContainerItem(containerItemSupplier.get());
         if (maxDamage != null) ((ItemDamageAccessor) item).callSetMaxDamage(maxDamage);

--- a/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/ItemBuilder.java
@@ -46,8 +46,9 @@ public final class ItemBuilder implements Cloneable {
      *
      * @param key Override translation key for the {@link Item}
      * @return Copy of {@link ItemBuilder}
+     * @deprecated Use the {@link Item} constructor to provide a language key
      */
-    @Deprecated
+    @Deprecated(since = "6.1.0")
     @SuppressWarnings({"unused"})
     public ItemBuilder setKey(String key) {
         ItemBuilder builder = this.clone();

--- a/src/main/java/turniplabs/halplibe/util/ArrayUtils.java
+++ b/src/main/java/turniplabs/halplibe/util/ArrayUtils.java
@@ -1,0 +1,25 @@
+package turniplabs.halplibe.util;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.lang.reflect.Array;
+
+@NullMarked
+public final class ArrayUtils {
+
+    @SuppressWarnings("unchecked")
+    public static <T> T[] newArray(Class<?> clazz, final int length) {
+        return (T[]) Array.newInstance(clazz, length);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T[] addAll(final T[] first, final T[] second) {
+        T[] newArr = (T[]) Array.newInstance(second.getClass(), first.length + second.length);
+        System.arraycopy(first, 0, newArr, 0, first.length);
+        System.arraycopy(second, 0, newArr, first.length, second.length);
+
+        return newArr;
+    }
+
+    private ArrayUtils() {}
+}

--- a/src/main/java/turniplabs/halplibe/util/ArrayUtils.java
+++ b/src/main/java/turniplabs/halplibe/util/ArrayUtils.java
@@ -8,13 +8,13 @@ import java.lang.reflect.Array;
 public final class ArrayUtils {
 
     @SuppressWarnings("unchecked")
-    public static <T> T[] newArray(Class<?> clazz, final int length) {
+    public static <T> T[] newArray(final Class<?> clazz, final int length) {
         return (T[]) Array.newInstance(clazz, length);
     }
 
     @SuppressWarnings("unchecked")
     public static <T> T[] addAll(final T[] first, final T[] second) {
-        T[] newArr = (T[]) Array.newInstance(second.getClass(), first.length + second.length);
+        final T[] newArr = (T[]) Array.newInstance(second.getClass().getComponentType(), first.length + second.length);
         System.arraycopy(first, 0, newArr, 0, first.length);
         System.arraycopy(second, 0, newArr, first.length, second.length);
 


### PR DESCRIPTION
## Changes
- Removed Apache Commons Lang 3
 It was used in two places at most, not really necessary
- "Removed" GSON
 BTA includes this in the jar, explicit implementation isn't needed afaik
- Replaced ``filesMatching`` with ``copySpec`` to suppress gradle warnings
- Updated README
- Added ArrayUtils to replace ACL3 functionality
- Slight tweaks to ItemBuilder logic
- Annotations tweaks to ItemBuilder and BlockBuilder
- Fixed setTags having the same behavior as addTags in both builders
- Removed all instances of IntelliJ nullability annotations
- Replace Guava with just Error Prone, make JSpecify compileOnly

**ItemBuilder**
- ``setTags`` now *actually* sets the tags, instead of doing the same thing as ``addTags``
- Fixed ``item.`` prefix not being added to item keys
- ~~``setKey`` now has the same behavior as the Item constructor~~
  > ~~The key ``foo.bar`` will be turned into ``item.MOD_ID.foo.bar`` in both cases~~
  > ~~Side note: I assume this was intentionally left "broken" to avoid breaking mods in which case this can be reverted, but I'd be very displeased~~
- Reverted setKey change, now marked as deprecated instead

This ended up being a bit of a messy pr, but it should only warrant a patch release in theory, will update once it is tested.

## Build system changes
This is an attempt at resolving the transitive dependency hell plaguing the maven publications.
- The only ``implementation`` is now fabric loader, because HalpLibe explicitly uses fabric loader classes
- Libraries shipped with BTA are now defined with ``compileOnly`` and exist mostly to provide their respective documentation, they will not be included in any builds and can freely be removed/added whenever (assuming that BTA actually includes them)
- Google Error Prone and JSpecify are also ``compileOnly`` dependencies, they can be used to annotate methods as usual, but referring to their classes during runtime is illegal
- Optional dev env only "dependencies" such as ModMenu are now defined with ``localRuntime``, which makes it only available at runtime without including it in any builds (this avoids modmenu bleeding into everything as a runtime dependency)
- Natives are also defined with ``localRuntime`` for similar reasons
- The beta jar is now defined with ``runtimeClasspath``, which is also not present in any builds. How this actually differs from ``localRuntime`` is not clear, but defining it with ``localRuntime`` causes an error.
- Now all outdated ``manifest.json`` dependencies are excluded instead of just LWJGL 2