### PR TITLE
Fix AFTER_BLOCK_INIT event

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 val lwjglNatives = resolveLwjglNatives()
 
-val modVersion: Provider<String> = providers.gradleProperty("mod_version")
+val modVersion: String = "${providers.gradleProperty("mod_version").get()}+${libs.versions.bta.get()}"
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
 val modName: Provider<String> = providers.gradleProperty("mod_name")
 
@@ -17,9 +17,11 @@ val javaVersion: Provider<Int> = libs.versions.java.map { it.toInt() }
 
 base.archivesName = modName
 group = modGroup.get()
-version = modVersion.get()
+version = modVersion
 loom {
-    customMinecraftMetadata.set("https://downloads.betterthanadventure.net/bta-client/${libs.versions.btaChannel.get()}/${libs.versions.bta.get()}/manifest.json")
+    val btaChannel = libs.versions.btaChannel.get()
+    val btaVersion = (if (btaChannel == "nightly") "" else "v") + libs.versions.bta.get()
+    customMinecraftMetadata.set("https://downloads.betterthanadventure.net/bta-client/${btaChannel}/${btaVersion}/manifest.json")
 }
 repositories {
     mavenCentral()
@@ -112,7 +114,7 @@ tasks {
     }
     processResources {
         val resourceMap = mapOf(
-            "version" to modVersion.get(),
+            "version" to modVersion,
             "fabricloader" to libs.versions.loader.get(),
             "java" to libs.versions.java.get(),
             "modmenu" to libs.versions.modMenu.get()
@@ -154,7 +156,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = modGroup.get()
             artifactId = modName.get()
-            version = modVersion.get()
+            version = modVersion
             from(components["java"])
         }
     }
@@ -166,7 +168,7 @@ if (modrinthToken.isPresent) {
     modrinth {
         token = modrinthToken
         projectId = "halplibe"
-        versionName = modVersion.map { "HalpLibe $it" }
+        versionName = "HalpLibe $modVersion"
         versionNumber = modVersion
         versionType = "release"
         uploadFile.set(tasks.jar)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ gradleJava = "21"
 ##########################################################################
 # Mod Dependencies
 # Check this on https://downloads.betterthanadventure.net/bta-client/
-bta = "v8.0-pre3"
+bta = "8.0-pre3"
 # Options are release, prerelease, nightly, and misc.
 btaChannel = "prerelease"
 # Check this on https://maven.thesignalumproject.net/#/infrastructure/net/fabricmc/fabric-loader/

--- a/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
@@ -6,7 +6,23 @@ public final class CommonEvents {
     public static final SortedSingleEvent<Runnable> BEFORE_GAME_START = new SortedSingleEvent<>("BeforeGameStart");
     public static final SortedSingleEvent<Runnable> AFTER_GAME_START = new SortedSingleEvent<>("AfterGameStart");
 
+    /**
+     * Guarantees that all {@link net.minecraft.core.block.BlockLogic Block} instances created before this event are
+     * non-null. Blocks created by BTA can always be referenced in this event. </br></br>
+     * <b>NOTE:</b> This does not mean that any of its lazily initialized fields will be available
+     * (such as the {@link net.minecraft.core.block.BlockLogic BlockLogic}), thus referencing them will lead to errors.
+     * Only use the Block instance itself.
+     * @see CommonEvents#AFTER_ITEM_INIT
+     */
     public static final SortedSingleEvent<Runnable> AFTER_BLOCK_INIT = new SortedSingleEvent<>("AfterBlockInit");
+
+    /**
+     * Guarantees that all {@link net.minecraft.core.item.Item Item} instances created before this event are non-null.
+     * Items created by BTA can always be referenced in this event. In addition, this event is called
+     * after all {@link net.minecraft.core.block.Block Blocks} have been fully initialized, so you may freely refer to
+     * any Block and its fields (including ones lazily initialized).
+     * @see CommonEvents#AFTER_BLOCK_INIT
+     */
     public static final SortedSingleEvent<Runnable> AFTER_ITEM_INIT = new SortedSingleEvent<>("AfterItemInit");
 
     public static final SortedSingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SortedSingleEvent<>("RecipesNamespaceInit");

--- a/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
@@ -1,5 +1,6 @@
 package turniplabs.halplibe.event.defs;
 
+import turniplabs.halplibe.event.impl.SortedBaseEvent;
 import turniplabs.halplibe.event.impl.SortedSingleEvent;
 
 public final class CommonEvents {
@@ -25,7 +26,7 @@ public final class CommonEvents {
      */
     public static final SortedSingleEvent<Runnable> AFTER_ITEM_INIT = new SortedSingleEvent<>("AfterItemInit");
 
-    public static final SortedSingleEvent<Runnable> RECIPES_NAMESPACE_INIT = new SortedSingleEvent<>("RecipesNamespaceInit");
+    public static final SortedBaseEvent<Runnable> RECIPES_NAMESPACE_INIT = new SortedBaseEvent<>();
     public static final SortedSingleEvent<Runnable> RECIPES_READY = new SortedSingleEvent<>("RecipesReady");
 
     private CommonEvents() {}

--- a/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
+++ b/src/main/java/turniplabs/halplibe/helper/BlockBuilder.java
@@ -329,7 +329,7 @@ public final class BlockBuilder implements Cloneable {
             CreativeInventoryRegistry.INSTANCE.register(block, creativeInventoryPlacement);
         }
 
-        if (BlocksAccessor.hasInit()) {
+        if (Internal.isBlocksInitComplete) {
             block.init();
             block.getLogic().initializeBlock();
             BlocksAccessor.cacheBlock(block);
@@ -422,6 +422,23 @@ public final class BlockBuilder implements Cloneable {
                         supplier.validate();
                     }
             );
+        }
+    }
+
+    /**
+     * This class only exists to "hide" internal static methods that need to be accessible
+     */
+    public static final class Internal {
+        /**
+         * Set to true in {@link turniplabs.halplibe.mixin.BlocksMixin BlocksMixin} after
+         * every Block has been fully initialized by {@link Blocks#init()}
+         * */
+        static boolean isBlocksInitComplete;
+
+        private Internal() {}
+
+        public static void markBlocksInitComplete() {
+            isBlocksInitComplete = true;
         }
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/BlocksMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/BlocksMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.event.defs.CommonEvents;
+import turniplabs.halplibe.helper.BlockBuilder;
 import turniplabs.halplibe.util.BlockInitEntrypoint;
 
 @Mixin(value = Blocks.class, remap = false)
@@ -15,5 +16,10 @@ public abstract class BlocksMixin {
     private static void afterBlockInit(CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
         CommonEvents.AFTER_BLOCK_INIT.emit(Runnable::run);
+    }
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private static void completeInit(CallbackInfo ci) {
+        BlockBuilder.Internal.markBlocksInitComplete();
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/BlocksMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/BlocksMixin.java
@@ -1,0 +1,19 @@
+package turniplabs.halplibe.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.block.Blocks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.event.defs.CommonEvents;
+import turniplabs.halplibe.util.BlockInitEntrypoint;
+
+@Mixin(value = Blocks.class, remap = false)
+public abstract class BlocksMixin {
+    @Inject(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;resetCaches()V", shift = At.Shift.AFTER))
+    private static void afterBlockInit(CallbackInfo ci) {
+        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
+        CommonEvents.AFTER_BLOCK_INIT.emit(Runnable::run);
+    }
+}

--- a/src/main/java/turniplabs/halplibe/mixin/GameSettingsMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/GameSettingsMixin.java
@@ -19,5 +19,6 @@ public abstract class GameSettingsMixin {
         FabricLoader.getInstance()
                 .getEntrypoints("initOptions", OptionsInitEntrypoint.class)
                 .forEach(OptionsInitEntrypoint::initOptions);
+        // Note: Deliberately has no matching Event variant as this is now unnecessary
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/ItemsMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/ItemsMixin.java
@@ -1,13 +1,19 @@
 package turniplabs.halplibe.mixin;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.event.defs.CommonEvents;
+import turniplabs.halplibe.util.ItemInitEntrypoint;
 
 @Mixin(value = Items.class)
 public abstract class ItemsMixin {
-    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;initStats()V"))
-    private static void delayInitStats() {
+    @Inject(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;initStats()V"))
+    private static void afterItemInit(CallbackInfo ci) {
+        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
+        CommonEvents.AFTER_ITEM_INIT.emit(Runnable::run);
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -17,10 +17,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import turniplabs.halplibe.HalpLibe;
 import turniplabs.halplibe.event.defs.ClientEvents;
 import turniplabs.halplibe.event.defs.CommonEvents;
-import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryRegistry;
 import turniplabs.halplibe.helper.network.NetworkHandler;
-import turniplabs.halplibe.mixin.accessors.ItemsAccessor;
-import turniplabs.halplibe.util.*;
+import turniplabs.halplibe.util.ClientStartEntrypoint;
+import turniplabs.halplibe.util.GameStartEntrypoint;
+import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Environment(EnvType.CLIENT)
 @Mixin(value = Minecraft.class)
@@ -70,22 +70,5 @@ public abstract class MinecraftMixin {
                     .build();
             displayScreen(popup);
         }
-    }
-
-    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.BEFORE))
-    public void afterBlockInitEntrypoint(CallbackInfo ci) {
-        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
-        CommonEvents.AFTER_BLOCK_INIT.emit(Runnable::run);
-    }
-
-    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.BEFORE))
-    public void afterItemInitEntrypoint(CallbackInfo ci) {
-        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
-        CommonEvents.AFTER_ITEM_INIT.emit(Runnable::run);
-    }
-
-    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/achievement/stat/StatList;init()V"))
-    public void initStats(CallbackInfo ci) {
-        ItemsAccessor.invokeInitStats();
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -16,10 +16,7 @@ import turniplabs.halplibe.event.defs.CommonEvents;
 import turniplabs.halplibe.event.defs.ServerEvents;
 import turniplabs.halplibe.helper.creativeInventory.CreativeInventoryRegistry;
 import turniplabs.halplibe.helper.network.NetworkHandler;
-import turniplabs.halplibe.mixin.accessors.ItemsAccessor;
-import turniplabs.halplibe.util.BlockInitEntrypoint;
 import turniplabs.halplibe.util.GameStartEntrypoint;
-import turniplabs.halplibe.util.ItemInitEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 @Environment(EnvType.SERVER)
@@ -55,22 +52,8 @@ public abstract class MinecraftServerMixin {
         CommonEvents.AFTER_GAME_START.emit(Runnable::run);
     }
 
-    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Blocks;init()V", shift = At.Shift.BEFORE))
-    public void afterBlockInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
-        FabricLoader.getInstance().getEntrypoints("afterBlockInit", BlockInitEntrypoint.class).forEach(BlockInitEntrypoint::afterBlockInit);
-        CommonEvents.AFTER_BLOCK_INIT.emit(Runnable::run);
-    }
-
-    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/item/Items;init()V", shift = At.Shift.BEFORE))
-    public void afterItemInitEntrypoint(CallbackInfoReturnable<Boolean> cir) {
-        FabricLoader.getInstance().getEntrypoints("afterItemInit", ItemInitEntrypoint.class).forEach(ItemInitEntrypoint::afterItemInit);
-        CommonEvents.AFTER_ITEM_INIT.emit(Runnable::run);
-    }
-
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/achievement/stat/StatList;init()V"))
-    public void initStats(CallbackInfoReturnable<Boolean> cir) {
-        ItemsAccessor.invokeInitStats();
-
+    public void printRecovery(CallbackInfoReturnable<Boolean> cir) {
         //before game start is too early and after game start is too late so thats why this is here
         if (HalpLibe.CONFIG.getBoolean("recoveryMode")) {
             HalpLibe.LOGGER.warn(I18n.getInstance().translateKey("halplibe.recoveryMode"));

--- a/src/main/java/turniplabs/halplibe/mixin/PacketHandlerClientMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/PacketHandlerClientMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import turniplabs.halplibe.event.defs.CommonEvents;
 import turniplabs.halplibe.helper.network.UniversalPacket;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
@@ -16,6 +17,7 @@ public abstract class PacketHandlerClientMixin {
     @Inject(method = "handleLogin", at = @At(value = "TAIL"))
     public void handleLogin(PacketLogin packetLogin, CallbackInfo ci) {
         FabricLoader.getInstance().getEntrypoints("recipesReady", RecipeEntrypoint.class).forEach(RecipeEntrypoint::initNamespaces);
+        CommonEvents.RECIPES_NAMESPACE_INIT.emit(Runnable::run);
     }
 
     @Inject(method = "handleCustomPayload", at = @At(value = "TAIL"))

--- a/src/main/java/turniplabs/halplibe/mixin/accessors/BlocksAccessor.java
+++ b/src/main/java/turniplabs/halplibe/mixin/accessors/BlocksAccessor.java
@@ -3,16 +3,10 @@ package turniplabs.halplibe.mixin.accessors;
 import net.minecraft.core.block.Block;
 import net.minecraft.core.block.Blocks;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(value = Blocks.class)
 public interface BlocksAccessor {
-    @Accessor("hasInit")
-    static boolean hasInit() {
-        throw new AssertionError();
-    }
-
     @Invoker("cacheBlock")
     static void cacheBlock(Block<?> container) {
         throw new AssertionError();

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -7,6 +7,7 @@
   "package": "turniplabs.halplibe.mixin",
   "compatibilityLevel": "JAVA_${java}",
   "mixins": [
+    "BlocksMixin",
     "CreativeMenuContentsMixin",
     "ItemsMixin",
     "MobCreeperMixin",


### PR DESCRIPTION
- Fixed ``AFTER_BLOCK_INIT`` being called too late
- Moved ``AFTER_ITEM_INIT`` call inside ``Items::init`` 
- Removed Item stat initialization delaying, as using ``AFTER_ITEM_INIT`` should work properly now
- Added docs to both events to warn of potential pitfalls

Misc:
- Version string now includes the targeted BTA version