### PR TITLE
ConfigHandler and TomlConfigHandler fixes

### DIFF
--- a/src/main/java/turniplabs/halplibe/HalpLibe.java
+++ b/src/main/java/turniplabs/halplibe/HalpLibe.java
@@ -9,6 +9,7 @@ import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import turniplabs.halplibe.helper.network.NetworkHandler;
+import turniplabs.halplibe.util.HalpLibeUtils;
 import turniplabs.halplibe.util.TomlConfigHandler;
 import turniplabs.halplibe.util.deathcause.DeathCauseNetworkMessage;
 import turniplabs.halplibe.util.toml.Toml;
@@ -19,6 +20,14 @@ import java.io.IOException;
 public class HalpLibe implements ModInitializer {
     public static final boolean isClient = FabricLoader.getInstance().getEnvironmentType().equals(EnvType.CLIENT);
     public static final String MOD_ID = HalpLibe.registerMod("halplibe", false);
+
+    /**
+     * Deprecated to avoid bleeding game class imports into utility classes that
+     * don't need to refer to them. If an isolated utility class needs a logging either use {@link HalpLibeUtils} or
+     * create new private logger.
+     * @deprecated See {@link HalpLibeUtils}
+     */
+    @Deprecated(forRemoval = true)
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     public static final TomlConfigHandler CONFIG;
 

--- a/src/main/java/turniplabs/halplibe/util/ConfigHandler.java
+++ b/src/main/java/turniplabs/halplibe/util/ConfigHandler.java
@@ -1,7 +1,6 @@
 package turniplabs.halplibe.util;
 
 import net.fabricmc.loader.api.FabricLoader;
-import turniplabs.halplibe.HalpLibe;
 
 import java.io.*;
 import java.util.Properties;
@@ -17,13 +16,13 @@ public class ConfigHandler {
         this.defaultProperties = defaultProperties;
         this.properties = new Properties();
         this.properties.putAll(defaultProperties);
-        HalpLibe.LOGGER.info("Config file name: " + this.properties);
+        HalpLibeUtils.LOGGER.info("Config file name: " + this.properties);
 
         File configFile = new File(getFilePath());
-        HalpLibe.LOGGER.info("Config file path: " + configFile.getAbsolutePath());
+        HalpLibeUtils.LOGGER.info("Config file path: " + configFile.getAbsolutePath());
         try {
             if (!configFile.exists()) {
-                HalpLibe.LOGGER.info("Config file does not exist. Creating...");
+                HalpLibeUtils.LOGGER.info("Config file does not exist. Creating...");
                 configFile.getParentFile().mkdirs();
                 configFile.createNewFile();
                 writeDefaultConfig(configFile, this.defaultProperties);
@@ -39,7 +38,7 @@ public class ConfigHandler {
     }
 
     private static void writeDefaultConfig(File configFile, Properties properties) {
-        HalpLibe.LOGGER.info("Writing default config to " + configFile.getAbsolutePath());
+        HalpLibeUtils.LOGGER.info("Writing default config to " + configFile.getAbsolutePath());
         try (OutputStream output = new FileOutputStream(configFile)) {
             properties.store(output, "Default config values");
             output.close();
@@ -49,7 +48,7 @@ public class ConfigHandler {
     }
 
     private static void updateConfig(File configFile, Properties properties) {
-        HalpLibe.LOGGER.info("Updating config at " + configFile.getAbsolutePath());
+        HalpLibeUtils.LOGGER.info("Updating config at " + configFile.getAbsolutePath());
         try (OutputStream output = new FileOutputStream(configFile)) {
             properties.store(output, "Updated config values");
             output.close();

--- a/src/main/java/turniplabs/halplibe/util/HalpLibeUtils.java
+++ b/src/main/java/turniplabs/halplibe/util/HalpLibeUtils.java
@@ -6,8 +6,8 @@ import org.slf4j.LoggerFactory;
 
 @NullMarked
 public final class HalpLibeUtils {
-    // IMPORTANT: This class should NEVER refer to game classes. The "halplibe" string deliberate does
-    // not refer to the HalpLibe class.
+    // IMPORTANT: This class should NEVER refer to game classes. The "halplibe" string deliberately does
+    // not use MOD_ID from the HalpLibe class.
     public static final Logger LOGGER = LoggerFactory.getLogger("halplibe");
 
     private HalpLibeUtils() {}

--- a/src/main/java/turniplabs/halplibe/util/HalpLibeUtils.java
+++ b/src/main/java/turniplabs/halplibe/util/HalpLibeUtils.java
@@ -1,0 +1,14 @@
+package turniplabs.halplibe.util;
+
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@NullMarked
+public final class HalpLibeUtils {
+    // IMPORTANT: This class should NEVER refer to game classes. The "halplibe" string deliberate does
+    // not refer to the HalpLibe class.
+    public static final Logger LOGGER = LoggerFactory.getLogger("halplibe");
+
+    private HalpLibeUtils() {}
+}

--- a/src/main/java/turniplabs/halplibe/util/TomlConfigHandler.java
+++ b/src/main/java/turniplabs/halplibe/util/TomlConfigHandler.java
@@ -1,7 +1,6 @@
 package turniplabs.halplibe.util;
 
 import net.fabricmc.loader.api.FabricLoader;
-import turniplabs.halplibe.HalpLibe;
 import turniplabs.halplibe.util.toml.Toml;
 import turniplabs.halplibe.util.toml.TomlParser;
 
@@ -40,11 +39,11 @@ public class TomlConfigHandler {
     //creates the actual config file
     public void create(){
         File configFile = new File(getFilePath());
-        HalpLibe.LOGGER.info("Config file name: " + this.configFileName);
-        HalpLibe.LOGGER.info("Config file path: " + configFile.getAbsolutePath());
+        HalpLibeUtils.LOGGER.info("Config file name: " + this.configFileName);
+        HalpLibeUtils.LOGGER.info("Config file path: " + configFile.getAbsolutePath());
         try {
             if (!configFile.exists()) {
-                HalpLibe.LOGGER.info("Config file does not exist. Creating...");
+                HalpLibeUtils.LOGGER.info("Config file does not exist. Creating...");
                 configFile.getParentFile().mkdirs();
                 configFile.createNewFile();
                 writeConfig();


### PR DESCRIPTION
Fixes ``ConfigHandler`` and ``TomlConfigHandler`` indirectly referring to game classes by using the Logger from ``HalpLibe``.

**Changes**
The static ``LOGGER`` field in ``HalpLibe`` is now deprecated to avoid similar issues in the future. There is a new logger instance in ``HalpLibeUtils``, which does not (and should not) reference any game class. The config handler classes now use this new logger.