### PR TITLE
HudEntrypoint & DimensionEntrypoint

### DIFF
--- a/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/ClientEvents.java
@@ -16,6 +16,10 @@ import java.util.function.Consumer;
 public final class ClientEvents {
     public static final SortedSingleEvent<Runnable> BEFORE_CLIENT_START = new SortedSingleEvent<>("BeforeClientStart");
     public static final SortedSingleEvent<Runnable> AFTER_CLIENT_START = new SortedSingleEvent<>("AfterClientStart");
+    /**
+     * For hud to resets correct please register them at this event.
+    * */
+    public static final SortedSingleEvent<Runnable> HUD_INIT = new SortedSingleEvent<>("HudInitialization");
 
     public static final SortedBaseEvent<Consumer<BlockModelDispatcher>> BLOCK_MODEL_RELOAD = new SortedBaseEvent<>();
     public static final SortedBaseEvent<Consumer<ItemModelDispatcher>> ITEM_MODEL_RELOAD = new SortedBaseEvent<>();

--- a/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
+++ b/src/main/java/turniplabs/halplibe/event/defs/CommonEvents.java
@@ -3,6 +3,9 @@ package turniplabs.halplibe.event.defs;
 import turniplabs.halplibe.event.impl.SortedBaseEvent;
 import turniplabs.halplibe.event.impl.SortedSingleEvent;
 
+import java.awt.*;
+import java.util.function.Consumer;
+
 public final class CommonEvents {
     public static final SortedSingleEvent<Runnable> BEFORE_GAME_START = new SortedSingleEvent<>("BeforeGameStart");
     public static final SortedSingleEvent<Runnable> AFTER_GAME_START = new SortedSingleEvent<>("AfterGameStart");
@@ -25,6 +28,12 @@ public final class CommonEvents {
      * @see CommonEvents#AFTER_BLOCK_INIT
      */
     public static final SortedSingleEvent<Runnable> AFTER_ITEM_INIT = new SortedSingleEvent<>("AfterItemInit");
+
+    /**
+     * Guarantees that all BTA {@link net.minecraft.core.world.Dimension} are registered before any of the custom dimension are.
+     * This prevents read out order error from occurring when BTA dimensions are read though list indexing.
+     * */
+    public static final SortedSingleEvent<Runnable> DIMENSION_REGISTRY = new SortedSingleEvent<>("DimensionRegistry");
 
     public static final SortedBaseEvent<Runnable> RECIPES_NAMESPACE_INIT = new SortedBaseEvent<>();
     public static final SortedSingleEvent<Runnable> RECIPES_READY = new SortedSingleEvent<>("RecipesReady");

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.Screen;
 import net.minecraft.client.gui.popup.PopupBuilder;
 import net.minecraft.client.gui.popup.PopupScreen;
 import net.minecraft.core.lang.I18n;
+import net.minecraft.core.world.Dimension;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -70,5 +71,15 @@ public abstract class MinecraftMixin {
                     .build();
             displayScreen(popup);
         }
+    }
+
+    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/net/command/util/CommandHelper;init()V"))
+    public void hudInitializationEntrypoint(CallbackInfo ci) {
+        ClientEvents.HUD_INIT.emit(Runnable::run);
+    }
+
+    @Inject(method = "startGame", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/Dimension;init()V", shift = At.Shift.AFTER))
+    public void dimensionRegistry(CallbackInfo ci) {
+        CommonEvents.DIMENSION_REGISTRY.emit(Runnable::run);
     }
 }

--- a/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/MinecraftServerMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import turniplabs.halplibe.HalpLibe;
 import turniplabs.halplibe.event.defs.CommonEvents;
@@ -61,6 +62,11 @@ public abstract class MinecraftServerMixin {
             HalpLibe.LOGGER.warn(I18n.getInstance().translateKey("halplibe.recoveryMode.text2"));
             HalpLibe.LOGGER.warn(I18n.getInstance().translateKey("halplibe.recoveryMode.action1"));
         }
+    }
+
+    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/Dimension;init()V", shift = At.Shift.AFTER))
+    public void dimensionRegistry(CallbackInfoReturnable<Boolean> cir) {
+        CommonEvents.DIMENSION_REGISTRY.emit(Runnable::run);
     }
 
     /*

--- a/src/main/java/turniplabs/halplibe/mixin/SaveConversionFix.java
+++ b/src/main/java/turniplabs/halplibe/mixin/SaveConversionFix.java
@@ -1,0 +1,60 @@
+package turniplabs.halplibe.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.world.Dimension;
+import net.minecraft.core.world.ProgressListener;
+import net.minecraft.core.world.save.conversion.SaveConverterMCRegionBase;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import turniplabs.halplibe.util.HalpLibeUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+
+@Mixin(value = SaveConverterMCRegionBase.class, remap = false)
+public class SaveConversionFix {
+    /**
+     * <p>The original BTA code uses a counter to resolve the dimension.
+     * This counter would count from 0 to the {@link Dimension#getDimensionList()} length.
+     * Not only was this missing dimensions with an {@link Dimension#id} greater than 2,
+     * but it would also corrupt worlds if a custom dimension was initialized before the BTA dimensions.
+     * </p>
+     * </br>
+     * This mixin fixes this by resolving the dimension ID through the directory name instead of using the counter.</br>
+     */
+    @WrapOperation(
+            method = "convertSave",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/core/world/save/conversion/SaveConverterMCRegionBase;convertDimensionRegions(Lnet/minecraft/core/world/Dimension;Ljava/util/ArrayList;IILnet/minecraft/core/world/ProgressListener;)I"
+            )
+    )
+    private int fixConversionBug(
+            SaveConverterMCRegionBase instance,
+            @NotNull Dimension dimension,
+            @NotNull ArrayList<File> files,
+            int numberOfConversion, int totalConversions,
+            @NotNull ProgressListener progressListener,
+            Operation<Integer> original,
+            @Local(name = "dimensionDir")File dir
+
+    ) {
+        String name = dir.getName();
+        int id;
+        try {
+            id = Integer.parseInt(name);
+        } catch (NumberFormatException e) {
+            HalpLibeUtils.LOGGER.error("Skipping dimension conversion. Directory '{}' does is not a valid numeric dimension id.", name, e);
+            return 0;
+        }
+        Dimension correctDim = Dimension.getDimensionList().get(id);
+        if(correctDim == null){
+            HalpLibeUtils.LOGGER.error("Skipping dimension conversion. No dimension is registered with id {}. (directory '{}').", id, name);
+            return 0;
+        }
+        return original.call(instance, Dimension.getDimensionList().get(id), files, numberOfConversion, totalConversions, progressListener);
+    }
+}

--- a/src/main/java/turniplabs/halplibe/mixin/deathcause/MobMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/deathcause/MobMixin.java
@@ -39,7 +39,7 @@ public abstract class MobMixin implements DeathCauseMixinInterface {
     private void resolveDeathMessages(Entity entityKilledBy, CallbackInfoReturnable<String> cir) {
         Mob asThis = (Mob) (Object) this;
         MOB_DEATH_HANDLER.emit(func -> this.deathCause = func.apply(asThis, entityKilledBy));
-        if(this.deathCause == null || this.deathCause instanceof DeathCauseGeneric){
+        if(this.deathCause == null){
             this.deathCause = this.emulateVanillaBehavior(asThis, entityKilledBy);
         }
     }

--- a/src/main/java/turniplabs/halplibe/mixin/deathcause/PlayerMixin.java
+++ b/src/main/java/turniplabs/halplibe/mixin/deathcause/PlayerMixin.java
@@ -27,7 +27,7 @@ public abstract class PlayerMixin extends MobMixin{
     private void resolveDeathMessages(Entity entityKilledBy, CallbackInfoReturnable<String> cir) {
         Player asThis = (Player) (Object) this;
         PLAYER_DEATH_HANDLER.emit(func -> this.deathCause = func.apply(asThis, entityKilledBy));
-        if(this.deathCause == null || this.deathCause instanceof DeathCauseGeneric){
+        if(this.deathCause == null){
             this.deathCause = this.emulateVanillaBehavior(asThis, entityKilledBy);
         }
     }

--- a/src/main/java/turniplabs/halplibe/util/deathcause/DeathCauseEvents.java
+++ b/src/main/java/turniplabs/halplibe/util/deathcause/DeathCauseEvents.java
@@ -17,6 +17,7 @@ public class DeathCauseEvents {
      * <p>
      *     The resulting {@link DeathCause} is automatically bound to the player, so
      *     calling {@link DeathCause#bind(Mob)} is not necessary.
+     *     Make sure to return null when none of the DeathCauses apply!
      *     For more information on how the handler gets resolved see {@link turniplabs.halplibe.mixin.deathcause.PlayerMixin}
      *     and {@link DeathCause}.
      *</p>
@@ -47,7 +48,6 @@ public class DeathCauseEvents {
      *      }
      * }
      * </pre>
-     *
      */
     public static final SortedBaseEvent<BiFunction<Player, Entity, DeathCause>> PLAYER_DEATH_HANDLER = new SortedBaseEvent<>();
 
@@ -58,6 +58,7 @@ public class DeathCauseEvents {
      * <p>
      *      The resulting {@link DeathCause} is automatically bound to the player, so
      *      calling {@link DeathCause#bind(Mob)} is not necessary.
+     *      Make sure to return null when none of the DeathCauses apply!
      *      For more information on how the handler gets resolved see {@link turniplabs.halplibe.mixin.deathcause.MobMixin}
      *      and {@link DeathCause}.
      * </p>
@@ -88,6 +89,7 @@ public class DeathCauseEvents {
      *      }
      * }
      * </pre>
+     *
      */
     public static final SortedBaseEvent<BiFunction<Mob, Entity, DeathCause>> MOB_DEATH_HANDLER = new SortedBaseEvent<>();
 }

--- a/src/main/resources/halplibe.mixins.json
+++ b/src/main/resources/halplibe.mixins.json
@@ -20,6 +20,7 @@
     "accessors.LanguageAccessor",
     "accessors.WeightedRandomBagAccessor",
     "accessors.WeightedRandomBagEntryAccessor",
+    "SaveConversionFix",
     "deathcause.MobMixin",
     "deathcause.PlayerMixin",
     "recovery.WorldMixin"


### PR DESCRIPTION
Adds two more entrypoint as well as fixes a BTA bug, when loading saves.

## HudInitialization (ClientEvent)
`HudEditor` cannot reset hud components that have been registred to late. To prevent late registration this entrypoint was
made to allow registring those in time.

## SaveConversionFix (Mixin)
The original BTA code uses a counter to resolve the dimension.
This counter would count from 0 to the `Dimension::getDimensionList()` length.
Not only was this missing dimensions with an `Dimension.id` greater than 2, but it would also corrupt worlds if a custom dimension was initialized before the BTA dimensions.

### Example:
Here the game attempts to convert OverWorld thinking it the Nether because the Aether was initialized before BTA dimensions.

<img width="1398" height="1266" alt="grafik" src="https://github.com/user-attachments/assets/7168b632-a22b-4104-96f6-176545514806" />

Just in case more issues pop up that require more fixing, I have added a event that at least guarntees that the base game wont f*ck with custom dimensions.

## DimensionRegistry (CommonEvent)
Given that the order and the timing matter this entrypoint was made to allow correct registration.
Guarantees that all `BTA Dimensions` are registered before any of the custom dimension are.
This prevents read out order error from occurring when BTA dimensions are read though list indexing.

## DeathCause
Fix of a small overside on the what is a valid return value for the specified api.
